### PR TITLE
Auto-Generated documentation with  PlatyPS

### DIFF
--- a/Docs/Add-ADDBSidHistory.md
+++ b/Docs/Add-ADDBSidHistory.md
@@ -1,0 +1,192 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Add-ADDBSidHistory
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Add-ADDBSidHistory -SidHistory <SecurityIdentifier[]> [-SkipMetaUpdate] [-SamAccountName] <String>
+ -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### BySID
+```
+Add-ADDBSidHistory -SidHistory <SecurityIdentifier[]> [-SkipMetaUpdate] -ObjectSid <SecurityIdentifier>
+ -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByDN
+```
+Add-ADDBSidHistory -SidHistory <SecurityIdentifier[]> [-SkipMetaUpdate] -DistinguishedName <String>
+ -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-ADDBSidHistory -SidHistory <SecurityIdentifier[]> [-SkipMetaUpdate] -ObjectGuid <Guid> -DBPath <String>
+ [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SidHistory
+TODO
+
+```yaml
+Type: SecurityIdentifier[]
+Parameter Sets: (All)
+Aliases: hist, History
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.Principal.SecurityIdentifier[]
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertFrom-ADManagedPasswordBlob.md
+++ b/Docs/ConvertFrom-ADManagedPasswordBlob.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-ADManagedPasswordBlob
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertFrom-ADManagedPasswordBlob [-Blob] <Byte[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Blob
+{{Fill Blob Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: msDS-ManagedPassword, ManagedPassword, ManagedPasswordBlob
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.ManagedPassword
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertFrom-GPPrefPassword.md
+++ b/Docs/ConvertFrom-GPPrefPassword.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-GPPrefPassword
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertFrom-GPPrefPassword [-EncryptedPassword] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -EncryptedPassword
+Provide an encrypted password from a Group Policy Preferences XML file.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertFrom-UnicodePassword.md
+++ b/Docs/ConvertFrom-UnicodePassword.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-UnicodePassword
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertFrom-UnicodePassword [-UnicodePassword] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -UnicodePassword
+{{Fill UnicodePassword Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-GPPrefPassword.md
+++ b/Docs/ConvertTo-GPPrefPassword.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-GPPrefPassword
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-GPPrefPassword [-Password] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Password
+Provide a password in the form of a SecureString.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases: p
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.SecureString
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-Hex.md
+++ b/Docs/ConvertTo-Hex.md
@@ -1,0 +1,76 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-Hex
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-Hex [-Input] <Byte[]> [-UpperCase] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Input
+{{Fill Input Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -UpperCase
+{{Fill UpperCase Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Byte[]
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-KerberosKey.md
+++ b/Docs/ConvertTo-KerberosKey.md
@@ -1,0 +1,91 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-KerberosKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-KerberosKey [-Password] <SecureString> [-Salt] <String> [[-Iterations] <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Iterations
+{{Fill Iterations Description}}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: i
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Provide a password in the form of a SecureString.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases: p
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Salt
+{{Fill Salt Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: s
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.KerberosKeyDataNew
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-LMHash.md
+++ b/Docs/ConvertTo-LMHash.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-LMHash
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-LMHash [-Password] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Password
+Provide a password in the form of a SecureString.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases: p
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.SecureString
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-NTHash.md
+++ b/Docs/ConvertTo-NTHash.md
@@ -1,0 +1,61 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-NTHash
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-NTHash [-Password] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Password
+Provide a password in the form of a SecureString.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases: p
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.SecureString
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-OrgIdHash.md
+++ b/Docs/ConvertTo-OrgIdHash.md
@@ -1,0 +1,99 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-OrgIdHash
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### FromHash (Default)
+```
+ConvertTo-OrgIdHash [-NTHash] <Byte[]> [[-Salt] <Byte[]>] [<CommonParameters>]
+```
+
+### FromPassword
+```
+ConvertTo-OrgIdHash [-Password] <SecureString> [[-Salt] <Byte[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -NTHash
+Provide a 16-byte NT Hash of user's password in hexadecimal format.
+
+```yaml
+Type: Byte[]
+Parameter Sets: FromHash
+Aliases: h
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Password
+Provide a password in the form of a SecureString.
+
+```yaml
+Type: SecureString
+Parameter Sets: FromPassword
+Aliases: p
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Salt
+Provide a 10-byte salt in hexadecimal format.
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: s
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.SecureString
+
+### System.Byte[]
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/ConvertTo-UnicodePassword.md
+++ b/Docs/ConvertTo-UnicodePassword.md
@@ -1,0 +1,76 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# ConvertTo-UnicodePassword
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+ConvertTo-UnicodePassword [-Password] <SecureString> [-IsUnattendPassword] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -IsUnattendPassword
+{{Fill IsUnattendPassword Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+{{Fill Password Description}}
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Disable-ADDBAccount.md
+++ b/Docs/Disable-ADDBAccount.md
@@ -1,0 +1,175 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Disable-ADDBAccount
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Disable-ADDBAccount [-SkipMetaUpdate] [-SamAccountName] <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### BySID
+```
+Disable-ADDBAccount [-SkipMetaUpdate] -ObjectSid <SecurityIdentifier> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByDN
+```
+Disable-ADDBAccount [-SkipMetaUpdate] -DistinguishedName <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByGuid
+```
+Disable-ADDBAccount [-SkipMetaUpdate] -ObjectGuid <Guid> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Enable-ADDBAccount.md
+++ b/Docs/Enable-ADDBAccount.md
@@ -1,0 +1,175 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Enable-ADDBAccount
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Enable-ADDBAccount [-SkipMetaUpdate] [-SamAccountName] <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### BySID
+```
+Enable-ADDBAccount [-SkipMetaUpdate] -ObjectSid <SecurityIdentifier> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByDN
+```
+Enable-ADDBAccount [-SkipMetaUpdate] -DistinguishedName <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByGuid
+```
+Enable-ADDBAccount [-SkipMetaUpdate] -ObjectGuid <Guid> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADDBAccount.md
+++ b/Docs/Get-ADDBAccount.md
@@ -1,0 +1,195 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADDBAccount
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### All
+```
+Get-ADDBAccount [-All] [-BootKey <Byte[]>] -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByName
+```
+Get-ADDBAccount [-BootKey <Byte[]>] [-SamAccountName] <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### BySID
+```
+Get-ADDBAccount [-BootKey <Byte[]>] -ObjectSid <SecurityIdentifier> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByDN
+```
+Get-ADDBAccount [-BootKey <Byte[]>] -DistinguishedName <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByGuid
+```
+Get-ADDBAccount [-BootKey <Byte[]>] -ObjectGuid <Guid> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -All
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: All
+Aliases: AllAccounts, ReturnAllAccounts
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BootKey
+TODO
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: key, SysKey
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### DSInternals.Common.Data.DSAccount
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADDBBackupKey.md
+++ b/Docs/Get-ADDBBackupKey.md
@@ -1,0 +1,91 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADDBBackupKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADDBBackupKey -BootKey <Byte[]> -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -BootKey
+TODO
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: key, SysKey
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.DPAPIBackupKey
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADDBDomainController.md
+++ b/Docs/Get-ADDBDomainController.md
@@ -1,0 +1,76 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADDBDomainController
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADDBDomainController -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.PowerShell.DomainController
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADDBKdsRootKey.md
+++ b/Docs/Get-ADDBKdsRootKey.md
@@ -1,0 +1,76 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADDBKdsRootKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADDBKdsRootKey -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.KdsRootKey
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADDBSchemaAttribute.md
+++ b/Docs/Get-ADDBSchemaAttribute.md
@@ -1,0 +1,91 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADDBSchemaAttribute
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADDBSchemaAttribute [[-Name] <String[]>] -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+TODO
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: LdapDisplayName,AttributeName,AttrName,Attr
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+
+## OUTPUTS
+
+### DSInternals.PowerShell.SchemaAttribute
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADKeyCredential.md
+++ b/Docs/Get-ADKeyCredential.md
@@ -1,0 +1,97 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADKeyCredential
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### FromCertificate (Default)
+```
+Get-ADKeyCredential [-Certificate] <X509Certificate2> [-DeviceId] <Guid> [<CommonParameters>]
+```
+
+### FromBinary
+```
+Get-ADKeyCredential [-Input] <Byte[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Certificate
+{{Fill Certificate Description}}
+
+```yaml
+Type: X509Certificate2
+Parameter Sets: FromCertificate
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeviceId
+{{Fill DeviceId Description}}
+
+```yaml
+Type: Guid
+Parameter Sets: FromCertificate
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Input
+{{Fill Input Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: FromBinary
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.KeyCredential
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADReplAccount.md
+++ b/Docs/Get-ADReplAccount.md
@@ -1,0 +1,227 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADReplAccount
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Get-ADReplAccount [-SamAccountName] <String> [-Domain] <String> -Server <String> [-Credential <PSCredential>]
+ [-Protocol <RpcProtocol>] [<CommonParameters>]
+```
+
+### BySID
+```
+Get-ADReplAccount -ObjectSid <SecurityIdentifier> -Server <String> [-Credential <PSCredential>]
+ [-Protocol <RpcProtocol>] [<CommonParameters>]
+```
+
+### All
+```
+Get-ADReplAccount [-All] -NamingContext <String> -Server <String> [-Credential <PSCredential>]
+ [-Protocol <RpcProtocol>] [<CommonParameters>]
+```
+
+### ByDN
+```
+Get-ADReplAccount -DistinguishedName <String> -Server <String> [-Credential <PSCredential>]
+ [-Protocol <RpcProtocol>] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Get-ADReplAccount -ObjectGuid <Guid> -Server <String> [-Credential <PSCredential>] [-Protocol <RpcProtocol>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -All
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: All
+Aliases: AllAccounts, ReturnAllAccounts
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+TODO
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Domain
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: AccountDomain, UserDomain
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NamingContext
+TODO
+
+```yaml
+Type: String
+Parameter Sets: All
+Aliases: NC, DomainNC, DomainNamingContext
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Protocol
+TODO
+
+```yaml
+Type: RpcProtocol
+Parameter Sets: (All)
+Aliases: Proto, RPCProtocol, NCACN
+Accepted values: TCP, SMB, HTTP
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam, AccountName, User
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Server
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Host, DomainController, DC
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### DSInternals.Common.Data.DSAccount
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADReplBackupKey.md
+++ b/Docs/Get-ADReplBackupKey.md
@@ -1,0 +1,108 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADReplBackupKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADReplBackupKey -Domain <String> -Server <String> [-Credential <PSCredential>] [-Protocol <RpcProtocol>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Credential
+TODO
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Domain
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: FQDN, DomainName, DNSDomainName
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Protocol
+TODO
+
+```yaml
+Type: RpcProtocol
+Parameter Sets: (All)
+Aliases: Proto, RPCProtocol, NCACN
+Accepted values: TCP, SMB, HTTP
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Host, DomainController, DC
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.DPAPIBackupKey
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-ADSIAccount.md
+++ b/Docs/Get-ADSIAccount.md
@@ -1,0 +1,76 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-ADSIAccount
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-ADSIAccount [-Server <String>] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Credential
+{{Fill Credential Description}}
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+{{Fill Server Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Host, DomainController, DC
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.Common.Data.DSAccount
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-BootKey.md
+++ b/Docs/Get-BootKey.md
@@ -1,0 +1,82 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-BootKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### Offline
+```
+Get-BootKey [-SystemHiveFilePath] <String> [<CommonParameters>]
+```
+
+### Online
+```
+Get-BootKey [-Online] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Online
+{{Fill Online Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Online
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SystemHiveFilePath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: Offline
+Aliases: Path, FilePath, SystemHivePath, HivePath
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.String
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-SamPasswordPolicy.md
+++ b/Docs/Get-SamPasswordPolicy.md
@@ -1,0 +1,92 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Get-SamPasswordPolicy
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Get-SamPasswordPolicy -Domain <String> [-Credential <PSCredential>] [-Server <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Credential
+Specify the user account credentials to use to perform this task.
+The default credentials are the credentials of the currently logged on user.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Domain
+Specify AD domain.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specify the name of a SAM server.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### DSInternals.SAM.Interop.SamDomainPasswordInformation
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -1,0 +1,112 @@
+---
+Module Name: DSInternals
+Module Guid: {{ Update Module Guid }}
+Download Help Link: {{ Update Download Link }}
+Help Version: {{ Update Help Version }}
+Locale: {{ Update Locale }}
+---
+
+# DSInternals Module
+## Description
+{{Manually Enter Description Here}}
+
+## DSInternals Cmdlets
+### [Add-ADDBSidHistory](Add-ADDBSidHistory.md)
+{{Fill in the Synopsis}}
+
+### [ConvertFrom-ADManagedPasswordBlob](ConvertFrom-ADManagedPasswordBlob.md)
+{{Fill in the Synopsis}}
+
+### [ConvertFrom-GPPrefPassword](ConvertFrom-GPPrefPassword.md)
+{{Fill in the Synopsis}}
+
+### [ConvertFrom-UnicodePassword](ConvertFrom-UnicodePassword.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-GPPrefPassword](ConvertTo-GPPrefPassword.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-Hex](ConvertTo-Hex.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-KerberosKey](ConvertTo-KerberosKey.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-LMHash](ConvertTo-LMHash.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-NTHash](ConvertTo-NTHash.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-OrgIdHash](ConvertTo-OrgIdHash.md)
+{{Fill in the Synopsis}}
+
+### [ConvertTo-UnicodePassword](ConvertTo-UnicodePassword.md)
+{{Fill in the Synopsis}}
+
+### [Disable-ADDBAccount](Disable-ADDBAccount.md)
+{{Fill in the Synopsis}}
+
+### [Enable-ADDBAccount](Enable-ADDBAccount.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADDBAccount](Get-ADDBAccount.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADDBBackupKey](Get-ADDBBackupKey.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADDBDomainController](Get-ADDBDomainController.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADDBKdsRootKey](Get-ADDBKdsRootKey.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADDBSchemaAttribute](Get-ADDBSchemaAttribute.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADKeyCredential](Get-ADKeyCredential.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADReplAccount](Get-ADReplAccount.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADReplBackupKey](Get-ADReplBackupKey.md)
+{{Fill in the Synopsis}}
+
+### [Get-ADSIAccount](Get-ADSIAccount.md)
+{{Fill in the Synopsis}}
+
+### [Get-BootKey](Get-BootKey.md)
+{{Fill in the Synopsis}}
+
+### [Get-SamPasswordPolicy](Get-SamPasswordPolicy.md)
+{{Fill in the Synopsis}}
+
+### [Remove-ADDBObject](Remove-ADDBObject.md)
+{{Fill in the Synopsis}}
+
+### [Save-DPAPIBlob](Save-DPAPIBlob.md)
+{{Fill in the Synopsis}}
+
+### [Set-ADDBAccountPassword](Set-ADDBAccountPassword.md)
+{{Fill in the Synopsis}}
+
+### [Set-ADDBAccountPasswordHash](Set-ADDBAccountPasswordHash.md)
+{{Fill in the Synopsis}}
+
+### [Set-ADDBBootKey](Set-ADDBBootKey.md)
+{{Fill in the Synopsis}}
+
+### [Set-ADDBDomainController](Set-ADDBDomainController.md)
+{{Fill in the Synopsis}}
+
+### [Set-ADDBPrimaryGroup](Set-ADDBPrimaryGroup.md)
+{{Fill in the Synopsis}}
+
+### [Set-SamAccountPasswordHash](Set-SamAccountPasswordHash.md)
+{{Fill in the Synopsis}}
+
+### [Test-PasswordQuality](Test-PasswordQuality.md)
+{{Fill in the Synopsis}}
+

--- a/Docs/Remove-ADDBObject.md
+++ b/Docs/Remove-ADDBObject.md
@@ -1,0 +1,162 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Remove-ADDBObject
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByDN
+```
+Remove-ADDBObject [-Force] -DistinguishedName <String> -DBPath <String> [-LogPath <String>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Remove-ADDBObject [-Force] -ObjectGuid <Guid> -DBPath <String> [-LogPath <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Force
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Save-DPAPIBlob.md
+++ b/Docs/Save-DPAPIBlob.md
@@ -1,0 +1,99 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Save-DPAPIBlob
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### FromObject
+```
+Save-DPAPIBlob -DPAPIObject <DPAPIObject> [-DirectoryPath] <String> [<CommonParameters>]
+```
+
+### FromAccount
+```
+Save-DPAPIBlob -Account <DSAccount> [-DirectoryPath] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Account
+{{Fill Account Description}}
+
+```yaml
+Type: DSAccount
+Parameter Sets: FromAccount
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -DPAPIObject
+{{Fill DPAPIObject Description}}
+
+```yaml
+Type: DPAPIObject
+Parameter Sets: FromObject
+Aliases: DPAPIBlob, Object, Blob, BackupKey
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -DirectoryPath
+{{Fill DirectoryPath Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Path, OutputPath
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### DSInternals.Common.Data.DPAPIObject
+
+### DSInternals.Common.Data.DSAccount
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-ADDBAccountPassword.md
+++ b/Docs/Set-ADDBAccountPassword.md
@@ -1,0 +1,207 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-ADDBAccountPassword
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Set-ADDBAccountPassword -NewPassword <SecureString> -BootKey <Byte[]> [-SkipMetaUpdate]
+ [-SamAccountName] <String> -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### BySID
+```
+Set-ADDBAccountPassword -NewPassword <SecureString> -BootKey <Byte[]> [-SkipMetaUpdate]
+ -ObjectSid <SecurityIdentifier> -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByDN
+```
+Set-ADDBAccountPassword -NewPassword <SecureString> -BootKey <Byte[]> [-SkipMetaUpdate]
+ -DistinguishedName <String> -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Set-ADDBAccountPassword -NewPassword <SecureString> -BootKey <Byte[]> [-SkipMetaUpdate] -ObjectGuid <Guid>
+ -DBPath <String> [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -BootKey
+{{Fill BootKey Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: Key, SysKey
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewPassword
+{{Fill NewPassword Description}}
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases: Password, Pwd, Pass, AccountPassword, p
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.SecureString
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-ADDBAccountPasswordHash.md
+++ b/Docs/Set-ADDBAccountPasswordHash.md
@@ -1,0 +1,228 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-ADDBAccountPasswordHash
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Set-ADDBAccountPasswordHash -NTHash <Byte[]> [-SupplementalCredentials <SupplementalCredentials>]
+ -BootKey <Byte[]> [-SkipMetaUpdate] [-SamAccountName] <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### BySID
+```
+Set-ADDBAccountPasswordHash -NTHash <Byte[]> [-SupplementalCredentials <SupplementalCredentials>]
+ -BootKey <Byte[]> [-SkipMetaUpdate] -ObjectSid <SecurityIdentifier> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByDN
+```
+Set-ADDBAccountPasswordHash -NTHash <Byte[]> [-SupplementalCredentials <SupplementalCredentials>]
+ -BootKey <Byte[]> [-SkipMetaUpdate] -DistinguishedName <String> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+### ByGuid
+```
+Set-ADDBAccountPasswordHash -NTHash <Byte[]> [-SupplementalCredentials <SupplementalCredentials>]
+ -BootKey <Byte[]> [-SkipMetaUpdate] -ObjectGuid <Guid> -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -BootKey
+{{Fill BootKey Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: Key, SysKey
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NTHash
+{{Fill NTHash Description}}
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: Hash, PasswordHash, NTLMHash, MD4Hash, h
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SupplementalCredentials
+{{Fill SupplementalCredentials Description}}
+
+```yaml
+Type: SupplementalCredentials
+Parameter Sets: (All)
+Aliases: KerberosKeys, sc, c
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Byte[]
+
+### DSInternals.Common.Data.SupplementalCredentials
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-ADDBBootKey.md
+++ b/Docs/Set-ADDBBootKey.md
@@ -1,0 +1,106 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-ADDBBootKey
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Set-ADDBBootKey -OldBootKey <Byte[]> [-NewBootKey <Byte[]>] -DBPath <String> [-LogPath <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewBootKey
+TODO
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: NewKey, New, NewSysKey
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OldBootKey
+TODO
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases: OldKey, Old, OldSysKey
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-ADDBDomainController.md
+++ b/Docs/Set-ADDBDomainController.md
@@ -1,0 +1,149 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-ADDBDomainController
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### USN
+```
+Set-ADDBDomainController [-Force] -DBPath <String> [-LogPath <String>] -HighestCommittedUsn <Int64>
+ [<CommonParameters>]
+```
+
+### Epoch
+```
+Set-ADDBDomainController [-Force] -DBPath <String> [-LogPath <String>] -Epoch <Int32> [<CommonParameters>]
+```
+
+### Expiration
+```
+Set-ADDBDomainController [-Force] -DBPath <String> [-LogPath <String>] -BackupExpiration <DateTime>
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -BackupExpiration
+{{Fill BackupExpiration Description}}
+
+```yaml
+Type: DateTime
+Parameter Sets: Expiration
+Aliases: Expiration, Expire
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Epoch
+{{Fill Epoch Description}}
+
+```yaml
+Type: Int32
+Parameter Sets: Epoch
+Aliases: DSAEpoch
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{Fill Force Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HighestCommittedUsn
+{{Fill HighestCommittedUsn Description}}
+
+```yaml
+Type: Int64
+Parameter Sets: USN
+Aliases: USN
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-ADDBPrimaryGroup.md
+++ b/Docs/Set-ADDBPrimaryGroup.md
@@ -1,0 +1,192 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-ADDBPrimaryGroup
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByName
+```
+Set-ADDBPrimaryGroup -PrimaryGroupId <Int32> [-SkipMetaUpdate] [-SamAccountName] <String> -DBPath <String>
+ [-LogPath <String>] [<CommonParameters>]
+```
+
+### BySID
+```
+Set-ADDBPrimaryGroup -PrimaryGroupId <Int32> [-SkipMetaUpdate] -ObjectSid <SecurityIdentifier> -DBPath <String>
+ [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByDN
+```
+Set-ADDBPrimaryGroup -PrimaryGroupId <Int32> [-SkipMetaUpdate] -DistinguishedName <String> -DBPath <String>
+ [-LogPath <String>] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Set-ADDBPrimaryGroup -PrimaryGroupId <Int32> [-SkipMetaUpdate] -ObjectGuid <Guid> -DBPath <String>
+ [-LogPath <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DBPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Database, DatabasePath, DatabaseFilePath, DBFilePath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DistinguishedName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByDN
+Aliases: dn
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LogPath
+TODO
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Log, TransactionLogPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectGuid
+TODO
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases: Guid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectSid
+TODO
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySID
+Aliases: Sid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PrimaryGroupId
+TODO
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: gid, Group, PrimaryGroup, GroupId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+TODO
+
+```yaml
+Type: String
+Parameter Sets: ByName
+Aliases: Login, sam
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SkipMetaUpdate
+TODO
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: SkipMeta, NoMetaUpdate, NoMeta, SkipObjMeta, NoObjMeta, SkipMetaDataUpdate, NoMetaDataUpdate
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Int32
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Guid
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Set-SamAccountPasswordHash.md
+++ b/Docs/Set-SamAccountPasswordHash.md
@@ -1,0 +1,164 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Set-SamAccountPasswordHash
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+### ByLogonName
+```
+Set-SamAccountPasswordHash -SamAccountName <String> -Domain <String> -NTHash <Byte[]> [-LMHash <Byte[]>]
+ [-Credential <PSCredential>] [-Server <String>] [<CommonParameters>]
+```
+
+### BySid
+```
+Set-SamAccountPasswordHash -Sid <SecurityIdentifier> -NTHash <Byte[]> [-LMHash <Byte[]>]
+ [-Credential <PSCredential>] [-Server <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Credential
+Specify the user account credentials to use to perform this task.
+The default credentials are the credentials of the currently logged on user.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Domain
+Specify the user's domain.
+
+```yaml
+Type: String
+Parameter Sets: ByLogonName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LMHash
+Specify a new LM password hash value in hexadecimal format.
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NTHash
+Specify a new NT password hash value in hexadecimal format.
+
+```yaml
+Type: Byte[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SamAccountName
+Specify user's login.
+
+```yaml
+Type: String
+Parameter Sets: ByLogonName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Server
+Specify the name of a SAM server.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Sid
+Specify user SID.
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: BySid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.Byte[]
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Test-PasswordQuality.md
+++ b/Docs/Test-PasswordQuality.md
@@ -1,0 +1,138 @@
+---
+external help file: DSInternals.PowerShell.dll-Help.xml
+Module Name: DSInternals
+online version:
+schema: 2.0.0
+---
+
+# Test-PasswordQuality
+
+## SYNOPSIS
+{{Fill in the Synopsis}}
+
+## SYNTAX
+
+```
+Test-PasswordQuality [-Account] <DSAccount> [-SkipDuplicatePasswordTest] [-IncludeDisabledAccounts]
+ [-WeakPasswords <String[]>] [-WeakPasswordsFile <String>] [-WeakPasswordHashesFile <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Account
+{{Fill Account Description}}
+
+```yaml
+Type: DSAccount
+Parameter Sets: (All)
+Aliases: ADAccount, DSAccount
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -IncludeDisabledAccounts
+{{Fill IncludeDisabledAccounts Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipDuplicatePasswordTest
+{{Fill SkipDuplicatePasswordTest Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WeakPasswordHashesFile
+{{Fill WeakPasswordHashesFile Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WeakPasswords
+{{Fill WeakPasswords Description}}
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WeakPasswordsFile
+{{Fill WeakPasswordsFile Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### DSInternals.Common.Data.DSAccount
+
+## OUTPUTS
+
+### DSInternals.PowerShell.PasswordQualityTestResult
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
I saw your issue #30. Thought you may want to have quick start. 

Following code was used to create and finally update docs. You can reuse this code to auto-regenerate docs. Just run it and it fixes needed things. New-MarkdownHelp is needed only once. 
```
Clear-Host
$Module = 'DSInternals'

Import-Module PlatyPS -Force

import-module $Module -force
#New-MarkdownHelp -Module $Module -OutputFolder $PSScriptRoot\..\docs
Update-MarkdownHelpModule $PSScriptRoot\..\docs -RefreshModulePage #-ModulePagePath "$PSScriptRoot\..\docs\Readme.md" #-Verbose
#New-ExternalHelp $PSScriptRoot\..\docs -OutputPath $PSScriptRoot\..\docs -Force
Move-Item "$PSScriptRoot\..\docs\$Module.md" -Destination "$PSScriptRoot\..\docs\Readme.md" -Force
```
