### PR TITLE
Test-PasswordQuality: Add SamAccountName as Password test

### DIFF
--- a/Src/DSInternals.PowerShell/Commands/Misc/TestPasswordQualityCommand.cs
+++ b/Src/DSInternals.PowerShell/Commands/Misc/TestPasswordQualityCommand.cs
@@ -473,19 +473,21 @@
         private void TestSamAccountNameAsPassword()
         {
             string userLowerPassword = this.Account.SamAccountName.ToLower();
-            string userExactPassword = this.Account.SamAccountName;
+            
             byte[] userLowerHash = NTHash.ComputeHash(userLowerPassword);
-            byte[] userExactHash = NTHash.ComputeHash(userExactPassword);
+            
             if (HashEqualityComparer.GetInstance().Equals(this.Account.NTHash, userLowerHash))
             {
                 // Username Password is lowercase SamAccountName
-
                 this.result.SamAccountNameAsPassword.Add(this.Account.LogonName);
             }
             else
             {
+                string userExactPassword = this.Account.SamAccountName;
+                byte[] userExactHash = NTHash.ComputeHash(userExactPassword);
                 if (HashEqualityComparer.GetInstance().Equals(this.Account.NTHash, userExactHash))
                 {
+                    
                     // Username Password is exact SamAccountName
                     this.result.SamAccountNameAsPassword.Add(this.Account.LogonName);
                 }

--- a/Src/DSInternals.PowerShell/Commands/Misc/TestPasswordQualityCommand.cs
+++ b/Src/DSInternals.PowerShell/Commands/Misc/TestPasswordQualityCommand.cs
@@ -234,7 +234,11 @@
                 // Skip the remaining tests, because they only make sense for non-empty passwords.
                 return;
             }
-
+            if (this.Account.SamAccountType == SamAccountType.User)
+            {
+                // Check if the user has the SamAccountName as password.
+                this.TestSamAccountNameAsPassword();
+            }
             if (this.Account.SamAccountType == SamAccountType.Computer)
             {
                 // Check if the computer has a default password.
@@ -464,6 +468,28 @@
             }
 
             accountList.Add(this.Account.LogonName);
+        }
+
+        private void TestSamAccountNameAsPassword()
+        {
+            string userLowerPassword = this.Account.SamAccountName.ToLower();
+            string userExactPassword = this.Account.SamAccountName;
+            byte[] userLowerHash = NTHash.ComputeHash(userLowerPassword);
+            byte[] userExactHash = NTHash.ComputeHash(userExactPassword);
+            if (HashEqualityComparer.GetInstance().Equals(this.Account.NTHash, userLowerHash))
+            {
+                // Username Password is lowercase SamAccountName
+
+                this.result.SamAccountNameAsPassword.Add(this.Account.LogonName);
+            }
+            else
+            {
+                if (HashEqualityComparer.GetInstance().Equals(this.Account.NTHash, userExactHash))
+                {
+                    // Username Password is exact SamAccountName
+                    this.result.SamAccountNameAsPassword.Add(this.Account.LogonName);
+                }
+            }
         }
 
         private void TestComputerDefaultPassword()

--- a/Src/DSInternals.PowerShell/Types/PasswordQualityTestResult.cs
+++ b/Src/DSInternals.PowerShell/Types/PasswordQualityTestResult.cs
@@ -28,6 +28,11 @@
         public ISet<string> WeakPassword = new SortedSet<string>();
 
         /// <summary>
+        /// List of user accounts with SamAccountName as passwords.
+        /// </summary>
+        public ISet<string> SamAccountNameAsPassword = new SortedSet<string>();
+
+        /// <summary>
         /// List of computer accounts with default passwords.
         /// </summary>
         public ISet<string> DefaultComputerPassword = new SortedSet<string>();

--- a/Src/DSInternals.PowerShell/Views/DSInternals.PasswordQualityTestResult.format.ps1xml
+++ b/Src/DSInternals.PowerShell/Views/DSInternals.PasswordQualityTestResult.format.ps1xml
@@ -89,6 +89,12 @@
                 <PropertyName>DuplicatePasswordGroups</PropertyName>
                 <CustomControlName>AccountGroupList</CustomControlName>
               </ExpressionBinding>
+              <Text>These user accounts have the SamAccountName as password:</Text>
+              <NewLine />
+              <ExpressionBinding>
+                <PropertyName>SamAccountNameAsPassword</PropertyName>
+                <CustomControlName>AccountList</CustomControlName>
+              </ExpressionBinding>
               <Text>These computer accounts have default passwords:</Text>
               <NewLine />
               <ExpressionBinding>


### PR DESCRIPTION
In some environments it is not uncommon to find user/service accounts with the SamAccountName as the Password. This commit adds this test to the Test-PasswordQuality command.