### PR TITLE
Replace Newtonsoft.Json with System.Text.Json

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@
 # Directory Services Internals<br/>PowerShell Module and Framework
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](../LICENSE.md)
-[![PowerShell 5.1 | 7](https://badgen.net/badge/icon/5.1%20|%207?icon=terminal&label=PowerShell)](#) 
+[![PowerShell 5.1 | 7](https://badgen.net/badge/icon/5.1%20|%207?icon=terminal&label=PowerShell)](#)
 [![Windows Server 2008 R2 | 2012 R2 | 2016 | 2019 | 2022 | 2025](https://badgen.net/badge/icon/2008%20R2%20|%202012%20R2%20|%202016%20|%202019%20|%202022%20|%202025?icon=windows&label=Windows%20Server)](#)
 
 [![.NET Framework 4.8+](https://img.shields.io/badge/Framework-4.8%2B-007FFF.svg?logo=.net)](#)
@@ -160,8 +160,7 @@ This project utilizes the following 3<sup>rd</sup> party copyrighted material:
 - [ManagedEsent](https://github.com/Microsoft/ManagedEsent) - Provides managed access to esent.dll, the embeddable database engine native to Windows.
 - [NDceRpc](https://github.com/OpenSharp/NDceRpc) - Integration of WCF and .NET with MS-RPC and binary serialization.
 - [PBKDF2.NET](https://github.com/therealmagicmike/PBKDF2.NET) - Provides PBKDF2 for .NET Framework.
-- [Bouncy Castle](https://www.bouncycastle.org/csharp/index.html) - A lightweight cryptography API for Java and C#. 
-- [Json.NET](https://github.com/JamesNK/Newtonsoft.Json) - Popular high-performance JSON framework for .NET.
+- [Bouncy Castle](https://www.bouncycastle.org/csharp/index.html) - A lightweight cryptography API for Java and C#.
 - [Peter O. CBOR](https://github.com/peteroupc/CBOR) - A C# implementation of Concise Binary Object Representation (RFC 7049).
 
 ## Related Projects

--- a/Scripts/Update-Licenses.ps1
+++ b/Scripts/Update-Licenses.ps1
@@ -20,9 +20,6 @@ $products = @(
         Name = 'Bouncy Castle';
         LicenseUrl = 'https://raw.githubusercontent.com/bcgit/bc-csharp/master/crypto/License.html'
      }, @{
-        Name = 'Json.NET';
-        LicenseUrl = 'https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/master/LICENSE.md'
-     }, @{
         Name = 'Peter O. CBOR Library';
         LicenseUrl = 'https://raw.githubusercontent.com/peteroupc/CBOR/master/LICENSE.md'
      }

--- a/Src/DSInternals.Common.Test/DSInternals.Common.Test.csproj
+++ b/Src/DSInternals.Common.Test/DSInternals.Common.Test.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DSInternals.Common\DSInternals.Common.csproj" />

--- a/Src/DSInternals.Common.Test/KeyCredentialTester.cs
+++ b/Src/DSInternals.Common.Test/KeyCredentialTester.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using DSInternals.Common.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
 
 namespace DSInternals.Common.Test
 {
@@ -10,6 +11,64 @@ namespace DSInternals.Common.Test
     public class KeyCredentialTester
     {
         private const string DummyDN = "CN=Account,DC=contoso,DC=com";
+
+        private static KeyCredential CreateSampleKey()
+        {
+            byte[] publicKey = "525341310008000003000000000100000000000000000000010001C1A78914457758B0B13C70C710C7F8548F3F9ED56AD4640B6E6A112655C98ECAC1CBD68A298F5686C08439428A97FE6FDF58D78EA481905182BAD684C2D9C5CDE1CDE34AA19742E8BBF58B953EAC4C562FCF598CC176B02DBE9FFFEF5937A65815C236F92892F7E511A1FEDD5483CB33F1EA715D68106180DED2432A293367114A6E325E62F93F73D7ECE4B6A2BCDB829D95C8645C3073B94BA7CB7515CD29042F0967201C6E24A77821E92A6C756DF79841ACBAAE11D90CA03B9FCD24EF9E304B5D35248A7BD70557399960277058AE3E99C7C7E2284858B7BF8B08CDD286964186A50A7FCBCC6A24F00FEE5B9698BBD3B1AEAD0CE81FEA461C0ABD716843A5".HexToBinary();
+            Guid deviceId = Guid.Parse("47f577e3-d2d0-4a0a-8aca-e0501098bde4");
+            DateTime creationTime = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return new KeyCredential(publicKey, deviceId, DummyDN, creationTime);
+        }
+
+        [TestMethod]
+        public void KeyCredential_RoundTrip_DoubleQuoted()
+        {
+            KeyCredential key = CreateSampleKey();
+            string json = key.ToJson();
+            KeyCredential result = KeyCredential.ParseJson(json);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key.Identifier, result.Identifier);
+            Assert.AreEqual(key.DeviceId, result.DeviceId);
+            Assert.AreEqual(key.CreationTime, result.CreationTime);
+        }
+
+        [TestMethod]
+        public void KeyCredential_Deserialize_SingleQuoted_Input()
+        {
+            KeyCredential key = CreateSampleKey();
+            string json = key.ToJson().Replace('"', '\'');
+            KeyCredential result = KeyCredential.ParseJson(json);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key.DeviceId, result.DeviceId);
+        }
+
+        [TestMethod]
+        public void KeyCredential_Deserialize_TrailingComma_And_Comments()
+        {
+            KeyCredential key = CreateSampleKey();
+            string json = key.ToJson();
+            string jsonWithComment = json.Insert(1, "\n  // comment\n");
+            jsonWithComment = jsonWithComment.Substring(0, jsonWithComment.Length - 1) + ",\n}";
+            KeyCredential result = KeyCredential.ParseJson(jsonWithComment);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(key.DeviceId, result.DeviceId);
+        }
+
+        [TestMethod]
+        public void Parse_SingleQuoted_WithEscapedApostrophe_Works()
+        {
+            var jsonSingleQuoted = "{ 'OwnerDN':'CN=O\\'Connor,DC=contoso,DC=com', 'IsComputerKey': false }";
+            var obj = KeyCredential.ParseJson(jsonSingleQuoted);
+            Assert.IsNotNull(obj);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(JsonException))]
+        public void Parse_BadJson_StillThrows()
+        {
+            var bad = "{ \"OwnerDN\": \"CN=User,DC=contoso,DC=com\" ";
+            _ = KeyCredential.ParseJson(bad);
+        }
 
         [TestMethod]
         public void KeyCredential_Parse_NonMFAKey()

--- a/Src/DSInternals.Common.Test/SearchableDeviceKeyTester.cs
+++ b/Src/DSInternals.Common.Test/SearchableDeviceKeyTester.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using DSInternals.Common.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace DSInternals.Common.Test
 {
@@ -38,7 +37,8 @@ namespace DSInternals.Common.Test
             Assert.AreEqual("cb69481e-8ff7-4039-93ec-0a2729a154a8", keyCredential.FidoKeyMaterial.AuthenticatorData.AttestedCredentialData.AaGuid.ToString());
 
             // Serialize the object again and compare with the original
-            Assert.AreEqual(JToken.Parse(jsonData).ToString(Formatting.None), keyCredential.ToJson());
+            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            Assert.AreEqual(normalized, keyCredential.ToJson());
         }
 
         [TestMethod]
@@ -91,7 +91,8 @@ namespace DSInternals.Common.Test
             Assert.AreEqual(2, keyCredential.FidoKeyMaterial.AttestationCertificates.Count);
 
             // Serialize the object again and compare with the original
-            Assert.AreEqual(JToken.Parse(jsonData).ToString(Formatting.None), keyCredential.ToJson());
+            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            Assert.AreEqual(normalized, keyCredential.ToJson());
         }
 
         [TestMethod]
@@ -119,7 +120,8 @@ namespace DSInternals.Common.Test
             Assert.AreEqual("cbad3c94-b480-4fa6-9187-ff1ed42c4479", parsedKey.DeviceId.Value.ToString().ToLowerInvariant());
 
             // Serialize the object again and compare with the original
-            Assert.AreEqual(JToken.Parse(jsonData).ToString(Formatting.None), parsedKey.ToJson());
+            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            Assert.AreEqual(normalized, parsedKey.ToJson());
 
             // Re-generate the identifier and check that it matches the value in AAD.
             var generatedKey = new KeyCredential(
@@ -131,7 +133,7 @@ namespace DSInternals.Common.Test
             Assert.AreEqual(parsedKey.Identifier, generatedKey.Identifier);
 
             // Serialize the generated object and compare with the original
-            Assert.AreEqual(JToken.Parse(jsonData).ToString(Formatting.None), generatedKey.ToJson());
+            Assert.AreEqual(normalized, generatedKey.ToJson());
         }
 
         [TestMethod]

--- a/Src/DSInternals.Common.Test/SearchableDeviceKeyTester.cs
+++ b/Src/DSInternals.Common.Test/SearchableDeviceKeyTester.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using DSInternals.Common.Data;
+using DSInternals.Common.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.Json;
 
@@ -37,7 +38,9 @@ namespace DSInternals.Common.Test
             Assert.AreEqual("cb69481e-8ff7-4039-93ec-0a2729a154a8", keyCredential.FidoKeyMaterial.AuthenticatorData.AttestedCredentialData.AaGuid.ToString());
 
             // Serialize the object again and compare with the original
-            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            string normalized = JsonSerializer.Serialize(
+                DsiJson.DeserializeLenient<JsonElement>(jsonData),
+                DsiJson.Options);
             Assert.AreEqual(normalized, keyCredential.ToJson());
         }
 
@@ -91,7 +94,9 @@ namespace DSInternals.Common.Test
             Assert.AreEqual(2, keyCredential.FidoKeyMaterial.AttestationCertificates.Count);
 
             // Serialize the object again and compare with the original
-            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            string normalized = JsonSerializer.Serialize(
+                DsiJson.DeserializeLenient<JsonElement>(jsonData),
+                DsiJson.Options);
             Assert.AreEqual(normalized, keyCredential.ToJson());
         }
 
@@ -120,7 +125,9 @@ namespace DSInternals.Common.Test
             Assert.AreEqual("cbad3c94-b480-4fa6-9187-ff1ed42c4479", parsedKey.DeviceId.Value.ToString().ToLowerInvariant());
 
             // Serialize the object again and compare with the original
-            string normalized = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(jsonData.Replace('\'', '"')));
+            string normalized = JsonSerializer.Serialize(
+                DsiJson.DeserializeLenient<JsonElement>(jsonData),
+                DsiJson.Options);
             Assert.AreEqual(normalized, parsedKey.ToJson());
 
             // Re-generate the identifier and check that it matches the value in AAD.

--- a/Src/DSInternals.Common.Test/packages.lock.json
+++ b/Src/DSInternals.Common.Test/packages.lock.json
@@ -11,6 +11,15 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -73,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -106,6 +115,11 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -172,11 +186,6 @@
         "resolved": "3.10.2",
         "contentHash": "WS9GHohjOzf653bqCSxplq3T25LAwFVeVrgLuotTiPDu+bO5bD7RgvXbkLqRqZGE2Qyuk/dbQpqa18PYAMXjMg=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -229,6 +238,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -265,25 +284,25 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "E5M5AE2OUTlCrf4omZvzzziUJO9CofBl+lXHaN5IKePPJvHqYFYYpaDPgCpR4VwaFbEebfnjOxxEBtPtsqAxpQ==",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.11",
-        "contentHash": "xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.1",
+          "System.Text.Encodings.Web": "9.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -304,11 +323,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }
@@ -486,8 +505,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -559,7 +578,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.Common.Test/packages.lock.json
+++ b/Src/DSInternals.Common.Test/packages.lock.json
@@ -11,15 +11,6 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -82,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -115,11 +106,6 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -240,8 +226,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -284,8 +270,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -294,15 +280,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -327,7 +313,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }

--- a/Src/DSInternals.Common/AzureAD/AzureADClient.cs
+++ b/Src/DSInternals.Common/AzureAD/AzureADClient.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using DSInternals.Common.Data;
 using DSInternals.Common.Exceptions;
+using DSInternals.Common.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
@@ -31,7 +32,6 @@ namespace DSInternals.Common.AzureAD
         private string _tenantId;
         private HttpClient _httpClient;
         private readonly string _batchSizeParameter;
-        private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         public AzureADClient(string accessToken, Guid? tenantId = null, int batchSize = MaxBatchSize)
         {
@@ -137,7 +137,7 @@ namespace DSInternals.Common.AzureAD
             // TODO: Switch to HttpMethod.Patch after migrating to .NET Standard 2.1 / .NET 5
             using (var request = new HttpRequestMessage(new HttpMethod("PATCH"), url.ToString()))
             {
-                request.Content = new StringContent(JsonSerializer.Serialize(properties, _jsonOptions), Encoding.UTF8, JsonContentType);
+                request.Content = new StringContent(JsonSerializer.Serialize(properties, DsiJson.Options), Encoding.UTF8, JsonContentType);
                 await SendODataRequest<object>(request).ConfigureAwait(false);
             }
         }
@@ -160,11 +160,11 @@ namespace DSInternals.Common.AzureAD
                         {
                             if (response.StatusCode == HttpStatusCode.OK)
                             {
-                                return await JsonSerializer.DeserializeAsync<T>(responseStream, _jsonOptions).ConfigureAwait(false);
+                                return await JsonSerializer.DeserializeAsync<T>(responseStream, DsiJson.Options).ConfigureAwait(false);
                             }
                             else
                             {
-                                var error = await JsonSerializer.DeserializeAsync<OdataErrorResponse>(responseStream, _jsonOptions).ConfigureAwait(false);
+                                var error = await JsonSerializer.DeserializeAsync<OdataErrorResponse>(responseStream, DsiJson.Options).ConfigureAwait(false);
                                 throw error.GetException();
                             }
                         }

--- a/Src/DSInternals.Common/AzureAD/AzureADClient.cs
+++ b/Src/DSInternals.Common/AzureAD/AzureADClient.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using DSInternals.Common.Data;
 using DSInternals.Common.Exceptions;
-using Newtonsoft.Json;
 
 namespace DSInternals.Common.AzureAD
 {
@@ -31,7 +31,7 @@ namespace DSInternals.Common.AzureAD
         private string _tenantId;
         private HttpClient _httpClient;
         private readonly string _batchSizeParameter;
-        private JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault();
+        private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         public AzureADClient(string accessToken, Guid? tenantId = null, int batchSize = MaxBatchSize)
         {
@@ -117,17 +117,17 @@ namespace DSInternals.Common.AzureAD
             // Vaidate the input
             Validator.AssertNotNullOrEmpty(userPrincipalName, nameof(userPrincipalName));
 
-            var properties = new Hashtable() { { KeyCredentialAttributeName, keyCredentials } };
+            var properties = new Dictionary<string, object> { { KeyCredentialAttributeName, keyCredentials } };
             await SetUserAsync(userPrincipalName, properties).ConfigureAwait(false);
         }
 
         public async Task SetUserAsync(Guid objectId, KeyCredential[] keyCredentials)
         {
-            var properties = new Hashtable() { { KeyCredentialAttributeName, keyCredentials } };
+            var properties = new Dictionary<string, object> { { KeyCredentialAttributeName, keyCredentials } };
             await SetUserAsync(objectId.ToString(), properties).ConfigureAwait(false);
         }
 
-        private async Task SetUserAsync(string userIdentifier, Hashtable properties)
+        private async Task SetUserAsync(string userIdentifier, Dictionary<string, object> properties)
         {
             // Build the request uri
             var url = new StringBuilder();
@@ -137,7 +137,7 @@ namespace DSInternals.Common.AzureAD
             // TODO: Switch to HttpMethod.Patch after migrating to .NET Standard 2.1 / .NET 5
             using (var request = new HttpRequestMessage(new HttpMethod("PATCH"), url.ToString()))
             {
-                request.Content = new StringContent(JsonConvert.SerializeObject(properties), Encoding.UTF8, JsonContentType);
+                request.Content = new StringContent(JsonSerializer.Serialize(properties, _jsonOptions), Encoding.UTF8, JsonContentType);
                 await SendODataRequest<object>(request).ConfigureAwait(false);
             }
         }
@@ -155,30 +155,26 @@ namespace DSInternals.Common.AzureAD
                     }
 
                     using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-                    using (var streamReader = new StreamReader(responseStream))
                     {
                         if (s_odataContentType.MediaType.Equals(response.Content.Headers.ContentType.MediaType, StringComparison.InvariantCultureIgnoreCase))
                         {
-                            // The response is a JSON document
-                            using (var jsonTextReader = new JsonTextReader(streamReader))
+                            if (response.StatusCode == HttpStatusCode.OK)
                             {
-                                if (response.StatusCode == HttpStatusCode.OK)
-                                {
-                                    return _jsonSerializer.Deserialize<T>(jsonTextReader);
-                                }
-                                else
-                                {
-                                    // Translate OData response to an exception
-                                    var error = _jsonSerializer.Deserialize<OdataErrorResponse>(jsonTextReader);
-                                    throw error.GetException();
-                                }
+                                return await JsonSerializer.DeserializeAsync<T>(responseStream, _jsonOptions).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                var error = await JsonSerializer.DeserializeAsync<OdataErrorResponse>(responseStream, _jsonOptions).ConfigureAwait(false);
+                                throw error.GetException();
                             }
                         }
                         else
                         {
-                            // The response is not a JSON document, so we parse its first line as message text
-                            string message = await streamReader.ReadLineAsync().ConfigureAwait(false);
-                            throw new GraphApiException(message, response.StatusCode.ToString());
+                            using (var streamReader = new StreamReader(responseStream))
+                            {
+                                string message = await streamReader.ReadLineAsync().ConfigureAwait(false);
+                                throw new GraphApiException(message, response.StatusCode.ToString());
+                            }
                         }
                     }
                 }

--- a/Src/DSInternals.Common/AzureAD/AzureADUser.cs
+++ b/Src/DSInternals.Common/AzureAD/AzureADUser.cs
@@ -1,42 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
 using DSInternals.Common.Data;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
-    [JsonObject(MemberSerialization = MemberSerialization.OptOut)]
     public class AzureADUser
     {
-        [JsonProperty("objectId", Required = Required.Always)]
+        [JsonPropertyName("objectId")]
+        [JsonRequired]
         public Guid ObjectId
         {
             get;
             private set;
         }
 
-        [JsonProperty("userPrincipalName", Required = Required.Always)]
+        [JsonPropertyName("userPrincipalName")]
+        [JsonRequired]
         public string UserPrincipalName
         {
             get;
             private set;
         }
 
-        [JsonProperty("accountEnabled")]
+        [JsonPropertyName("accountEnabled")]
         public bool Enabled
         {
             get;
             private set;
         }
 
-        [JsonProperty("displayName")]
+        [JsonPropertyName("displayName")]
         public string DisplayName
         {
             get;
             private set;
         }
 
-        [JsonProperty("searchableDeviceKey")]
+        [JsonPropertyName("searchableDeviceKey")]
         public List<KeyCredential> KeyCredentials
         {
             get;

--- a/Src/DSInternals.Common/AzureAD/ODataError.cs
+++ b/Src/DSInternals.Common/AzureAD/ODataError.cs
@@ -1,17 +1,18 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
     public class ODataError
     {
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code
         {
             get;
             private set;
         }
 
-        [JsonProperty("message", Required = Required.Always)]
+        [JsonPropertyName("message")]
+        [JsonRequired]
         public ODataErrorMessage Message
         {
             get;

--- a/Src/DSInternals.Common/AzureAD/ODataErrorMessage.cs
+++ b/Src/DSInternals.Common/AzureAD/ODataErrorMessage.cs
@@ -1,17 +1,18 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
     public class ODataErrorMessage
     {
-        [JsonProperty("lang")]
+        [JsonPropertyName("lang")]
         public string Language
         {
             get;
             private set;
         }
 
-        [JsonProperty("value", Required = Required.Always)]
+        [JsonPropertyName("value")]
+        [JsonRequired]
         public string Value
         {
             get;

--- a/Src/DSInternals.Common/AzureAD/OdataErrorResponse.cs
+++ b/Src/DSInternals.Common/AzureAD/OdataErrorResponse.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
     public class OdataErrorResponse
     {
-        [JsonProperty("odata.error", Required = Required.Always)]
+        [JsonPropertyName("odata.error")]
+        [JsonRequired]
         public ODataError Error
         {
             get;

--- a/Src/DSInternals.Common/AzureAD/OdataPagedResponse.cs
+++ b/Src/DSInternals.Common/AzureAD/OdataPagedResponse.cs
@@ -1,19 +1,18 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.AzureAD
 {
-    [JsonObject(MemberSerialization = MemberSerialization.OptOut)]
     public class OdataPagedResponse<T>
     {
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public List<T> Items
         {
             get;
             private set;
         }
 
-        [JsonProperty("odata.nextlink")]
+        [JsonPropertyName("odata.nextlink")]
         public string NextLink
         {
             get;

--- a/Src/DSInternals.Common/DSInternals.Common.csproj
+++ b/Src/DSInternals.Common/DSInternals.Common.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net472'" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="PeterO.Cbor" Version="4.5.5" />
     <PackageReference Include="System.Buffers" Version="4.5.1" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" />

--- a/Src/DSInternals.Common/DSInternals.Common.csproj
+++ b/Src/DSInternals.Common/DSInternals.Common.csproj
@@ -10,6 +10,7 @@
 - Added support for AD trusts.</PackageReleaseNotes>
     <PackageTags>ActiveDirectory Security Entra AD AAD Identity Active Directory</PackageTags>
     <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -21,13 +22,20 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="9.0.8" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="PeterO.Cbor" Version="4.5.5" />
     <PackageReference Include="System.Buffers" Version="4.5.1" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
     <PackageReference Include="System.Formats.Asn1" Version="9.0.8" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" Condition="'$(TargetFramework)' == 'net48'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="DSInternals.Common.Test" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/DSInternals.Common/DSInternals.Common.csproj
+++ b/Src/DSInternals.Common/DSInternals.Common.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net472'" />
     <PackageReference Include="PeterO.Cbor" Version="4.5.5" />
     <PackageReference Include="System.Buffers" Version="4.5.1" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" />

--- a/Src/DSInternals.Common/Data/Hello/CustomKeyInformationConverter.cs
+++ b/Src/DSInternals.Common/Data/Hello/CustomKeyInformationConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.Data
 {
@@ -9,40 +10,38 @@ namespace DSInternals.Common.Data
     /// </summary>
     public class CustomKeyInformationConverter : JsonConverter<CustomKeyInformation>
     {
-        public override CustomKeyInformation ReadJson(JsonReader reader, Type objectType, CustomKeyInformation existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override CustomKeyInformation Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonToken.Null)
+            if (reader.TokenType == JsonTokenType.Null)
             {
                 return null;
             }
 
-            if(reader.TokenType == JsonToken.String)
+            if(reader.TokenType == JsonTokenType.String)
             {
                 try
                 {
-                    byte[] blob = Convert.FromBase64String((string)reader.Value);
+                    byte[] blob = Convert.FromBase64String(reader.GetString());
                     return new CustomKeyInformation(blob);
                 }
                 catch(Exception e)
                 {
-                    throw new JsonSerializationException("Cannot convert invalid value to CustomKeyInformation.", e);
+                    throw new JsonException("Cannot convert invalid value to CustomKeyInformation.", e);
                 }
             }
-            else
-            {
-                throw new JsonSerializationException("Unexpected token parsing CustomKeyInformation.");
-            }
+
+            throw new JsonException("Unexpected token parsing CustomKeyInformation.");
         }
 
-        public override void WriteJson(JsonWriter writer, CustomKeyInformation value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, CustomKeyInformation value, JsonSerializerOptions options)
         {
             if(value != null)
             {
-                writer.WriteValue(value.ToByteArray());
+                writer.WriteStringValue(Convert.ToBase64String(value.ToByteArray()));
             }
             else
             {
-                writer.WriteNull();
+                writer.WriteNullValue();
             }
         }
     }

--- a/Src/DSInternals.Common/Data/Hello/KeyCredential.cs
+++ b/Src/DSInternals.Common/Data/Hello/KeyCredential.cs
@@ -353,7 +353,7 @@
             Validator.AssertNotNull(blob, nameof(blob));
             Validator.AssertMinLength(blob, MinLength, nameof(blob));
             Validator.AssertNotNullOrEmpty(owner, nameof(owner));
-            
+
             // Init
             this.Owner = owner;
 
@@ -549,8 +549,7 @@
             return new DNWithBinary(this.Owner, this.ToByteArray()).ToString();
         }
 
-        public string ToJson() =>
-            JsonSerializer.Serialize(this, DsiJson.Options);
+        public string ToJson() => JsonSerializer.Serialize(this, DsiJson.Options);
 
         public static KeyCredential ParseDNBinary(string dnWithBinary)
         {

--- a/Src/DSInternals.Common/Data/Hello/KeyCredential.cs
+++ b/Src/DSInternals.Common/Data/Hello/KeyCredential.cs
@@ -6,8 +6,8 @@
     using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
     using DSInternals.Common.Data.Fido;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     ///  This class represents a single AD/AAD key credential.
@@ -18,7 +18,6 @@
     /// The Azure Active Directory Graph API represents this structure in JSON format.
     /// </remarks>
     /// <see>https://msdn.microsoft.com/en-us/library/mt220505.aspx</see>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class KeyCredential
     {
         /// <summary>
@@ -44,6 +43,7 @@
         /// <summary>
         /// Defines the version of the structure.
         /// </summary>
+        [JsonIgnore]
         public KeyCredentialVersion Version
         {
             get;
@@ -56,13 +56,15 @@
         /// <remarks>
         /// Version 1 keys had a guid in this field instead if a hash.
         /// </remarks>
-        [JsonProperty("keyIdentifier", Order = 2)]
+        [JsonPropertyName("keyIdentifier")]
+        [JsonPropertyOrder(2)]
         public string Identifier
         {
             get;
             private set;
         }
 
+        [JsonIgnore]
         public bool IsWeak
         {
             get
@@ -72,20 +74,23 @@
             }
         }
 
-        [JsonProperty("usage", Order = 1)]
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonPropertyName("usage")]
+        [JsonPropertyOrder(1)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public KeyUsage Usage
         {
             get;
             private set;
         }
 
+        [JsonIgnore]
         public string LegacyUsage
         {
             get;
             private set;
         }
 
+        [JsonIgnore]
         public KeySource Source
         {
             get;
@@ -95,13 +100,15 @@
         /// <summary>
         /// Key material of the credential.
         /// </summary>
-        [JsonProperty("keyMaterial", Order = 3)]
+        [JsonPropertyName("keyMaterial")]
+        [JsonPropertyOrder(3)]
         public byte[] RawKeyMaterial
         {
             get;
             private set;
         }
 
+        [JsonIgnore]
         public KeyMaterialFido FidoKeyMaterial
         {
             get
@@ -110,7 +117,7 @@
                 {
                     // The raw value has not yet been parsed
                     var fidoCredString = System.Text.Encoding.UTF8.GetString(this.RawKeyMaterial, 0, this.RawKeyMaterial.Length);
-                    this._cachedFidoKeyMaterial = JsonConvert.DeserializeObject<KeyMaterialFido>(fidoCredString);
+                    this._cachedFidoKeyMaterial = JsonSerializer.Deserialize<KeyMaterialFido>(fidoCredString);
                 }
 
                 // Returned the parsed object from cache or NULL if no FIDO key is present.
@@ -118,6 +125,7 @@
             }
         }
 
+        [JsonIgnore]
         public ECParameters? ECPublicKey
         {
             get
@@ -134,6 +142,7 @@
             }
         }
 
+        [JsonIgnore]
         public RSAParameters? RSAPublicKey
         {
             get
@@ -177,6 +186,7 @@
             }
         }
 
+        [JsonIgnore]
         public string RSAModulus
         {
             get
@@ -186,7 +196,8 @@
             }
         }
 
-        [JsonProperty("customKeyInformation", Order = 6)]
+        [JsonPropertyName("customKeyInformation")]
+        [JsonPropertyOrder(6)]
         [JsonConverter(typeof(CustomKeyInformationConverter))]
         public CustomKeyInformation CustomKeyInfo
         {
@@ -194,7 +205,8 @@
             private set;
         }
 
-        [JsonProperty("deviceId", Order = 5)]
+        [JsonPropertyName("deviceId")]
+        [JsonPropertyOrder(5)]
         public Guid? DeviceId
         {
             get;
@@ -204,7 +216,8 @@
         /// <summary>
         /// The approximate time this key was created.
         /// </summary>
-        [JsonProperty("creationTime", Order = 4)]
+        [JsonPropertyName("creationTime")]
+        [JsonPropertyOrder(4)]
         public DateTime CreationTime
         {
             get;
@@ -214,6 +227,7 @@
         /// <summary>
         /// The approximate time this key was last used.
         /// </summary>
+        [JsonIgnore]
         public DateTime? LastLogonTime
         {
             get;
@@ -223,6 +237,7 @@
         /// <summary>
         /// Distinguished name of the AD object (UPN in case of AAD objects) that holds this key credential.
         /// </summary>
+        [JsonIgnore]
         public string Owner
         {
             get;
@@ -233,8 +248,9 @@
         /// <summary>
         /// Gets the FIDO AAGUID. For JSON deserialization only.
         /// </summary>
-        [JsonProperty("fidoAaGuid", Order = 7, ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        private Guid? FidoAaGuid
+        [JsonPropertyName("fidoAaGuid")]
+        [JsonPropertyOrder(7)]
+        public Guid? FidoAaGuid
         {
             get
             {
@@ -253,8 +269,9 @@
         /// <summary>
         /// Gets the FIDO authenticator version. For JSON deserialization only.
         /// </summary>
-        [JsonProperty("fidoAuthenticatorVersion", Order = 8, ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        private string FidoAuthenticatorVersion
+        [JsonPropertyName("fidoAuthenticatorVersion")]
+        [JsonPropertyOrder(8)]
+        public string FidoAuthenticatorVersion
         {
             get
             {
@@ -265,8 +282,9 @@
         /// <summary>
         /// Gets a list of thumbprints of FIDO Attestation Certificates. For JSON deserialization only.
         /// </summary>
-        [JsonProperty("fidoAttestationCertificates", Order = 9, ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        private string[] FidoAttestationCertificates
+        [JsonPropertyName("fidoAttestationCertificates")]
+        [JsonPropertyOrder(9)]
+        public string[] FidoAttestationCertificates
         {
             get
             {
@@ -277,7 +295,7 @@
                 }
                 else
                 {
-                    return new string[0];
+                    return Array.Empty<string>();
                 }
             }
         }
@@ -526,7 +544,7 @@
 
         public string ToJson()
         {
-            return JsonConvert.SerializeObject(this);
+            return JsonSerializer.Serialize(this);
         }
 
         public static KeyCredential ParseDNBinary(string dnWithBinary)
@@ -544,7 +562,8 @@
             }
             else
             {
-                return JsonConvert.DeserializeObject<KeyCredential>(jsonData);
+                jsonData = jsonData.Replace('\'', '"');
+                return JsonSerializer.Deserialize<KeyCredential>(jsonData);
             }
         }
 

--- a/Src/DSInternals.Common/Data/Hello/KeyMaterialFido.cs
+++ b/Src/DSInternals.Common/Data/Hello/KeyMaterialFido.cs
@@ -12,6 +12,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Version is an integer that specifies the version of the structure.
         /// </summary>
+        [JsonInclude]
         [JsonPropertyName("version")]
         public int Version
         {
@@ -23,6 +24,7 @@ namespace DSInternals.Common.Data
         /// AuthData is a WebAuthn authenticator data structure.
         /// <see>https://www.w3.org/TR/webauthn/#sec-authenticator-data</see>
         /// </summary>
+        [JsonInclude]
         [JsonPropertyName("authData")]
         public string AuthenticatorDataRaw
         {
@@ -33,6 +35,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// X5c is an array of attestation certificates associated with the authenticator.
         /// </summary>
+        [JsonInclude]
         [JsonPropertyName("x5c")]
         public string[] AttestationCertificatesRaw
         {
@@ -43,6 +46,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Display name is a user provided string which can help the user differentiate between multiple registered authenticators.
         /// </summary>
+        [JsonInclude]
         [JsonPropertyName("displayName")]
         public string DisplayName
         {

--- a/Src/DSInternals.Common/Data/Hello/KeyMaterialFido.cs
+++ b/Src/DSInternals.Common/Data/Hello/KeyMaterialFido.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.Data
 {
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class KeyMaterialFido
     {
         // All PEM certificates that are less than 16,383B long start with MII.
@@ -13,7 +12,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Version is an integer that specifies the version of the structure.
         /// </summary>
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public int Version
         {
             get;
@@ -24,7 +23,7 @@ namespace DSInternals.Common.Data
         /// AuthData is a WebAuthn authenticator data structure.
         /// <see>https://www.w3.org/TR/webauthn/#sec-authenticator-data</see>
         /// </summary>
-        [JsonProperty("authData")]
+        [JsonPropertyName("authData")]
         public string AuthenticatorDataRaw
         {
             get;
@@ -34,7 +33,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// X5c is an array of attestation certificates associated with the authenticator.
         /// </summary>
-        [JsonProperty("x5c")]
+        [JsonPropertyName("x5c")]
         public string[] AttestationCertificatesRaw
         {
             get;
@@ -44,7 +43,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Display name is a user provided string which can help the user differentiate between multiple registered authenticators.
         /// </summary>
-        [JsonProperty("displayName")]
+        [JsonPropertyName("displayName")]
         public string DisplayName
         {
             get;
@@ -54,6 +53,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Attestation certificates can be helpful for establishing a chain of trust.
         /// </summary>
+        [JsonIgnore]
         public X509Certificate2Collection AttestationCertificates
         {
             get
@@ -74,6 +74,7 @@ namespace DSInternals.Common.Data
         /// <summary>
         /// Authenticator data contains information about the registered authenticator device.
         /// </summary>
+        [JsonIgnore]
         public Fido.AuthenticatorData AuthenticatorData
         {
             get

--- a/Src/DSInternals.Common/Data/LAPS/LapsClearTextPassword.cs
+++ b/Src/DSInternals.Common/Data/LAPS/LapsClearTextPassword.cs
@@ -1,7 +1,8 @@
 ﻿using System.Globalization;
 using System;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DSInternals.Common.Data
 {
@@ -11,16 +12,16 @@ namespace DSInternals.Common.Data
     /// <seealso>https://learn.microsoft.com/en-us/windows-server/identity/laps/laps-technical-reference</seealso>
     public class LapsClearTextPassword
     {
-        [JsonProperty("n")]
+        [JsonPropertyName("n")]
         public string AccountName;
 
-        [JsonProperty("t")]
+        [JsonPropertyName("t")]
         public string UpdateTimestampString;
 
-        [JsonProperty("p")]
+        [JsonPropertyName("p")]
         public string Password;
 
-        [JsonIgnore()]
+        [JsonIgnore]
         public DateTime? UpdateTimestamp
         {
             get
@@ -48,7 +49,7 @@ namespace DSInternals.Common.Data
         public static LapsClearTextPassword Parse(string json)
         {
             Validator.AssertNotNull(json, nameof(json));
-            return JsonConvert.DeserializeObject<LapsClearTextPassword>(json);
+            return JsonSerializer.Deserialize<LapsClearTextPassword>(json);
         }
 
         public static unsafe LapsClearTextPassword Parse(ReadOnlySpan<byte> binaryJson, bool utf16 = false)

--- a/Src/DSInternals.Common/Data/LAPS/LapsClearTextPassword.cs
+++ b/Src/DSInternals.Common/Data/LAPS/LapsClearTextPassword.cs
@@ -1,8 +1,8 @@
 ﻿using System.Globalization;
 using System;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using DSInternals.Common.Serialization;
 
 namespace DSInternals.Common.Data
 {
@@ -49,18 +49,12 @@ namespace DSInternals.Common.Data
         public static LapsClearTextPassword Parse(string json)
         {
             Validator.AssertNotNull(json, nameof(json));
-            return JsonSerializer.Deserialize<LapsClearTextPassword>(json);
+            return DsiJson.DeserializeLenient<LapsClearTextPassword>(json);
         }
 
-        public static unsafe LapsClearTextPassword Parse(ReadOnlySpan<byte> binaryJson, bool utf16 = false)
+        public static LapsClearTextPassword Parse(ReadOnlySpan<byte> binaryJson, bool utf16 = false)
         {
-            var encoding = utf16 ? Encoding.Unicode : Encoding.UTF8;
-
-            fixed (byte* binaryJsonPtr = binaryJson)
-            {
-                string json = encoding.GetString(binaryJsonPtr, binaryJson.Length);
-                return Parse(json);
-            }
+            return DsiJson.DeserializeLenient<LapsClearTextPassword>(binaryJson, utf16);
         }
     }
 }

--- a/Src/DSInternals.Common/Serialization/DsiJson.cs
+++ b/Src/DSInternals.Common/Serialization/DsiJson.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DSInternals.Common.Serialization
+{
+    internal static class DsiJson
+    {
+        // One place to set behavior for all JSON in DSInternals
+        internal static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            IncludeFields = true, // LAPS uses fields (n/t/p)
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        static DsiJson()
+        {
+            Options.Converters.Add(new JsonStringEnumConverter());
+        }
+
+        // ---------- String input ----------
+        internal static T DeserializeLenient<T>(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return default;
+
+            // Strip UTF-8/UTF-16 BOM if present
+            if (json.Length > 0 && json[0] == '\uFEFF')
+                json = json.Substring(1);
+
+            try
+            {
+                return JsonSerializer.Deserialize<T>(json, Options);
+            }
+            catch (JsonException)
+            {
+                if (LooksLikeSingleQuotedJson(json))
+                {
+                    var normalized = NormalizeSingleQuotedJson(json);
+                    return JsonSerializer.Deserialize<T>(normalized, Options);
+                }
+                throw;
+            }
+        }
+
+        // ---------- Binary input ----------
+        internal static T DeserializeLenient<T>(ReadOnlySpan<byte> binaryJson, bool utf16 = false)
+        {
+            var json = DecodeJson(binaryJson, utf16);
+            return DeserializeLenient<T>(json);
+        }
+
+        internal static string DecodeJson(ReadOnlySpan<byte> binaryJson, bool utf16 = false)
+        {
+            // Trim terminators/padding on BYTES BEFORE decoding.
+            var trimmed = TrimZeroTerminator(binaryJson, utf16);
+
+#if NET8_0_OR_GREATER
+            string json = (utf16 ? Encoding.Unicode : Encoding.UTF8).GetString(trimmed);
+#else
+            // .NET Framework: no span GetString; copy to array explicitly.
+            byte[] buf = trimmed.Length == 0 ? Array.Empty<byte>() : new byte[trimmed.Length];
+            if (buf.Length != 0) 
+            {
+                for (int i = 0; i < trimmed.Length; i++)
+                {
+                    buf[i] = trimmed[i];
+                }
+            }
+            string json = (utf16 ? Encoding.Unicode : Encoding.UTF8).GetString(buf);
+#endif
+            // Strip BOM if present
+            if (json.Length > 0 && json[0] == '\uFEFF')
+                json = json.Substring(1);
+
+            return json;
+        }
+
+        private static ReadOnlySpan<byte> TrimZeroTerminator(ReadOnlySpan<byte> input, bool utf16)
+        {
+            if (input.Length == 0) return input;
+
+            if (utf16)
+            {
+                // Remove any number of trailing 0x00 0x00 pairs.
+                int len = input.Length;
+                while (len >= 2 && input[len - 1] == 0 && input[len - 2] == 0)
+                    len -= 2;
+
+                // Safety: ensure even byte count for UTF-16
+                if ((len & 1) == 1) len -= 1;
+
+                return input.Slice(0, len);
+            }
+            else
+            {
+                int len = input.Length;
+                while (len > 0 && input[len - 1] == 0)
+                    len--;
+                return input.Slice(0, len);
+            }
+        }
+
+        private static bool LooksLikeSingleQuotedJson(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return false;
+            var t = s.TrimStart();
+            return (t.Length > 0 && (t[0] == '{' || t[0] == '['))
+                   && s.IndexOf('"') < 0
+                   && s.IndexOf('\'') >= 0;
+        }
+
+        // Converts '…' to "…" and preserves apostrophes inside strings (\' -> ')
+        private static string NormalizeSingleQuotedJson(string input)
+        {
+            var sb = new StringBuilder(input.Length);
+            bool inString = false;
+            char quote = '\0';
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                char ch = input[i];
+
+                // Inside a single-quoted string, turn \' into a literal apostrophe
+                if (inString && quote == '\'' && ch == '\\' && i + 1 < input.Length && input[i + 1] == '\'')
+                {
+                    sb.Append('\'');
+                    i++; // skip the '
+                    continue;
+                }
+
+                if (ch == '\'' || ch == '"')
+                {
+                    if (!inString)
+                    {
+                        inString = true;
+                        quote = ch;
+                        sb.Append('"'); // open
+                        continue;
+                    }
+                    else if (ch == quote)
+                    {
+                        inString = false;
+                        sb.Append('"'); // close
+                        continue;
+                    }
+                }
+
+                sb.Append(ch);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Src/DSInternals.Common/Serialization/DsiJson.cs
+++ b/Src/DSInternals.Common/Serialization/DsiJson.cs
@@ -16,6 +16,7 @@ namespace DSInternals.Common.Serialization
             ReadCommentHandling = JsonCommentHandling.Skip,
             DefaultIgnoreCondition = JsonIgnoreCondition.Never,
             IncludeFields = true, // LAPS uses fields (n/t/p)
+            NumberHandling = JsonNumberHandling.AllowReadingFromString, // Newtonsoft parity for quoted numbers
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 

--- a/Src/DSInternals.Common/packages.lock.json
+++ b/Src/DSInternals.Common/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -22,12 +31,6 @@
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview",
           "Microsoft.Windows.WDK.Win32Metadata": "0.12.8-experimental"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Direct",
@@ -67,16 +70,45 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
       "System.ValueTuple": {
         "type": "Direct",
         "requested": "[4.6.1, )",
         "resolved": "4.6.1",
         "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -111,6 +143,16 @@
         "resolved": "1.0.0",
         "contentHash": "fpRTBsYACMp7NvTECauYRomubWTC3vUNw4hMXdIedP8ctBGK6tea9HOJwE+qVzis6MZYkL3LIs8qeY3rc6Jdlw=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -118,8 +160,26 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       }
     },
     "net8.0-windows7.0": {
@@ -143,12 +203,6 @@
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview",
           "Microsoft.Windows.WDK.Win32Metadata": "0.12.8-experimental"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Direct",

--- a/Src/DSInternals.Common/packages.lock.json
+++ b/Src/DSInternals.Common/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -72,16 +63,16 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -94,8 +85,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -104,11 +95,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -145,8 +131,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -165,8 +151,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",

--- a/Src/DSInternals.DataStore.Test/packages.lock.json
+++ b/Src/DSInternals.DataStore.Test/packages.lock.json
@@ -11,6 +11,15 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -86,8 +95,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -119,6 +128,11 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -185,11 +199,6 @@
         "resolved": "3.10.2",
         "contentHash": "WS9GHohjOzf653bqCSxplq3T25LAwFVeVrgLuotTiPDu+bO5bD7RgvXbkLqRqZGE2Qyuk/dbQpqa18PYAMXjMg=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -242,6 +251,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -278,25 +297,25 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "E5M5AE2OUTlCrf4omZvzzziUJO9CofBl+lXHaN5IKePPJvHqYFYYpaDPgCpR4VwaFbEebfnjOxxEBtPtsqAxpQ==",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.11",
-        "contentHash": "xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.1",
+          "System.Text.Encodings.Web": "9.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -317,11 +336,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },
@@ -520,8 +539,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -593,7 +612,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.DataStore.Test/packages.lock.json
+++ b/Src/DSInternals.DataStore.Test/packages.lock.json
@@ -11,15 +11,6 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -95,8 +86,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -128,11 +119,6 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -253,8 +239,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -297,8 +283,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -307,15 +293,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -340,7 +326,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },

--- a/Src/DSInternals.DataStore/packages.lock.json
+++ b/Src/DSInternals.DataStore/packages.lock.json
@@ -17,6 +17,15 @@
           "DSInternals.ManagedEsent.Interop": "2.0.4.1"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -38,10 +47,23 @@
           "Microsoft.Windows.WDK.Win32Metadata": "0.12.8-experimental"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -65,11 +87,6 @@
         "dependencies": {
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -105,6 +122,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -122,8 +149,41 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       },
       "System.ValueTuple": {
         "type": "Transitive",
@@ -133,11 +193,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }
@@ -207,11 +267,6 @@
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview"
         }
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -239,7 +294,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.DataStore/packages.lock.json
+++ b/Src/DSInternals.DataStore/packages.lock.json
@@ -17,15 +17,6 @@
           "DSInternals.ManagedEsent.Interop": "2.0.4.1"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -49,8 +40,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -59,11 +50,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -124,8 +110,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -154,8 +140,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -164,15 +150,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -197,7 +183,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }

--- a/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
+++ b/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
@@ -54,7 +54,7 @@
 
     <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Core -->
     <!-- TODO: This requires more testing. -->
-    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net472'" IncludeAssets="compile" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" Condition="'$(TargetFramework)' == 'net48'" IncludeAssets="compile" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" IncludeAssets="compile" />
 
     <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Desktop on Windows Server 2025, but are absent on Windows Server 2008 R2: -->

--- a/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
+++ b/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
@@ -54,7 +54,7 @@
 
     <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Core -->
     <!-- TODO: This requires more testing. -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" Condition="'$(TargetFramework)' == 'net8.0-windows'" IncludeAssets="compile" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net472'" IncludeAssets="compile" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" IncludeAssets="compile" />
 
     <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Desktop on Windows Server 2025, but are absent on Windows Server 2008 R2: -->

--- a/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
+++ b/Src/DSInternals.PowerShell/DSInternals.PowerShell.csproj
@@ -52,9 +52,7 @@
     <ProjectReference Include="..\DSInternals.Replication\DSInternals.Replication.csproj" />
     <ProjectReference Include="..\DSInternals.SAM\DSInternals.SAM.csproj" />
 
-    <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Core -->
-    <!-- TODO: This requires more testing. -->
-    <PackageReference Include="System.Text.Json" Version="9.0.8" Condition="'$(TargetFramework)' == 'net48'" IncludeAssets="compile" />
+    <!-- The following dependency from DSInternals.Common is already bundled with PowerShell Core -->
     <PackageReference Include="System.DirectoryServices" Version="9.0.8" Condition="'$(TargetFramework)' == 'net8.0-windows'" IncludeAssets="compile" />
 
     <!-- The following dependencies from DSInternals.Common are already bundled with PowerShell Desktop on Windows Server 2025, but are absent on Windows Server 2008 R2: -->

--- a/Src/DSInternals.PowerShell/DSInternals.psd1
+++ b/Src/DSInternals.PowerShell/DSInternals.psd1
@@ -186,7 +186,7 @@ FileList = @(
     'net48\x86\DSInternals.Replication.Interop.dll',
     'net48\Esent.Interop.dll',
     'net48\Esent.Isam.dll',
-    'net48\Newtonsoft.Json.dll',
+    'net48\System.Text.Json.dll',
     'net48\CBOR.dll',
     'net48\Numbers.dll',
     'net48\URIUtility.dll',

--- a/Src/DSInternals.PowerShell/License.txt
+++ b/Src/DSInternals.PowerShell/License.txt
@@ -4,7 +4,7 @@ The binary distribution of the DSInternals PowerShell Module contains the follow
 DSInternals PowerShell Module and Framework
 -------------------------------------------
 
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/MichaelGrafnetter/DSInternals/master/LICENSE.md.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/MichaelGrafnetter/DSInternals/master/LICENSE.md.)
 
 The MIT License (MIT)
 
@@ -33,7 +33,7 @@ SOFTWARE.
 ESENT Managed Interop
 ---------------------
 
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/microsoft/ManagedEsent/master/LICENSE.md.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/microsoft/ManagedEsent/master/LICENSE.md.)
 
 The MIT License (MIT)
 
@@ -61,18 +61,35 @@ SOFTWARE.
 NDceRpc (.NET Distributed Computing Environment Remote Procedure Call)
 ----------------------------------------------------------------------
 
-(License updated on 7/7/2019 from https://raw.githubusercontent.com/OpenSharp/NDceRpc/master/license.txt.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/OpenSharp/NDceRpc/master/license.txt.)
 
-CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
-http://creativecommons.org/publicdomain/zero/1.0/
+The MIT License (MIT)
 
-Other codes, if any used, are under MIT, CPOL, BSD, Apache, MS-PL.
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ----------
 PBKDF2.NET
 ----------
 
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/therealmagicmike/PBKDF2.NET/master/License.txt.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/therealmagicmike/PBKDF2.NET/master/License.txt.)
 
 Copyright (c) 2013 Michael Johnson
 
@@ -99,7 +116,7 @@ THE SOFTWARE.
 Bouncy Castle
 -------------
 
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/bcgit/bc-csharp/master/crypto/License.html.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/bcgit/bc-csharp/master/crypto/License.html.)
 
 License
 
@@ -128,39 +145,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
---------
-Json.NET
---------
-
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/master/LICENSE.md.)
-
-The MIT License (MIT)
-
-Copyright (c) 2007 James Newton-King
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
 ---------------------
 Peter O. CBOR Library
 ---------------------
 
-(License updated on 8/12/2025 from https://raw.githubusercontent.com/peteroupc/CBOR/master/LICENSE.md.)
+(License updated on 08/14/2025 from https://raw.githubusercontent.com/peteroupc/CBOR/master/LICENSE.md.)
 
 This is free and unencumbered software released into the public domain.
 
@@ -168,5 +157,5 @@ Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
 
 In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED ???AS IS???, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 

--- a/Src/DSInternals.PowerShell/License.txt
+++ b/Src/DSInternals.PowerShell/License.txt
@@ -4,7 +4,7 @@ The binary distribution of the DSInternals PowerShell Module contains the follow
 DSInternals PowerShell Module and Framework
 -------------------------------------------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/MichaelGrafnetter/DSInternals/master/LICENSE.md.)
+(License updated on 8/12/2025 from https://raw.githubusercontent.com/MichaelGrafnetter/DSInternals/master/LICENSE.md.)
 
 The MIT License (MIT)
 
@@ -33,7 +33,7 @@ SOFTWARE.
 ESENT Managed Interop
 ---------------------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/microsoft/ManagedEsent/master/LICENSE.md.)
+(License updated on 8/12/2025 from https://raw.githubusercontent.com/microsoft/ManagedEsent/master/LICENSE.md.)
 
 The MIT License (MIT)
 
@@ -61,35 +61,18 @@ SOFTWARE.
 NDceRpc (.NET Distributed Computing Environment Remote Procedure Call)
 ----------------------------------------------------------------------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/OpenSharp/NDceRpc/master/license.txt.)
+(License updated on 7/7/2019 from https://raw.githubusercontent.com/OpenSharp/NDceRpc/master/license.txt.)
 
-The MIT License (MIT)
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+http://creativecommons.org/publicdomain/zero/1.0/
 
-Copyright (c) Microsoft Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Other codes, if any used, are under MIT, CPOL, BSD, Apache, MS-PL.
 
 ----------
 PBKDF2.NET
 ----------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/therealmagicmike/PBKDF2.NET/master/License.txt.)
+(License updated on 8/12/2025 from https://raw.githubusercontent.com/therealmagicmike/PBKDF2.NET/master/License.txt.)
 
 Copyright (c) 2013 Michael Johnson
 
@@ -116,7 +99,7 @@ THE SOFTWARE.
 Bouncy Castle
 -------------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/bcgit/bc-csharp/master/crypto/License.html.)
+(License updated on 8/12/2025 from https://raw.githubusercontent.com/bcgit/bc-csharp/master/crypto/License.html.)
 
 License
 
@@ -149,7 +132,7 @@ DEALINGS IN THE SOFTWARE.
 Peter O. CBOR Library
 ---------------------
 
-(License updated on 08/14/2025 from https://raw.githubusercontent.com/peteroupc/CBOR/master/LICENSE.md.)
+(License updated on 8/12/2025 from https://raw.githubusercontent.com/peteroupc/CBOR/master/LICENSE.md.)
 
 This is free and unencumbered software released into the public domain.
 
@@ -157,5 +140,5 @@ Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
 
 In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
 
-THE SOFTWARE IS PROVIDED ???AS IS???, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 

--- a/Src/DSInternals.PowerShell/packages.lock.json
+++ b/Src/DSInternals.PowerShell/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -18,17 +27,28 @@
         "resolved": "5.1.1",
         "contentHash": "e31xJjG+Kjbv6YF3Yq6D4Dl3or8v7LrNF41k3CXrWozW6hR1zcOe5KYuZJaGSiAgLnwP8wcW+I3+IWEzMPZKXQ=="
       },
-      "DSInternals.ManagedEsent.Interop": {
-        "type": "Transitive",
-        "resolved": "2.0.4.1",
-        "contentHash": "WTcjhN/4l6C802QCBHctCZJZAGrVlI5TzVccS+P7s4axvfi0COjMEqHwhQJ4RdzsmblmemHAq4AQay/kc1e75Q=="
-      },
-      "DSInternals.ManagedEsent.Isam": {
-        "type": "Transitive",
-        "resolved": "2.0.4.1",
-        "contentHash": "ttkkBm6GIEylpxSAepD5u9pR8uP1Kf87Fmr0G4f5pgFW5oXRBGWPr8UCitWkx4hdg6hqTV12+IGOTU0oVSaDRA==",
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "DSInternals.ManagedEsent.Interop": "2.0.4.1"
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.Build.Tasks.Git": {
@@ -36,15 +56,15 @@
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -80,6 +100,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -97,8 +127,26 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       },
       "System.ValueTuple": {
         "type": "Transitive",
@@ -108,38 +156,30 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
-        }
-      },
-      "dsinternals.datastore": {
-        "type": "Project",
-        "dependencies": {
-          "DSInternals.Common": "[5.5.0, )",
-          "DSInternals.ManagedEsent.Interop": "[2.0.4.1, )",
-          "DSInternals.ManagedEsent.Isam": "[2.0.4.1, )"
         }
       },
       "dsinternals.replication": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       },
       "dsinternals.replication.model": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       },
       "dsinternals.sam": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       }
     },
@@ -154,12 +194,6 @@
           "Microsoft.SourceLink.Common": "8.0.0"
         }
       },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PowerShellStandard.Library": {
         "type": "Direct",
         "requested": "[5.1.1, )",
@@ -171,19 +205,6 @@
         "requested": "[9.0.8, )",
         "resolved": "9.0.8",
         "contentHash": "xN2JrOfhcOyswOflVZG27XlFJDPPqU7AQtAAStWcnKoC8W9XCLOLdAYIrrwiZMfeRhavVErI8HkSO/c2TQ+z2g=="
-      },
-      "DSInternals.ManagedEsent.Interop": {
-        "type": "Transitive",
-        "resolved": "2.0.4.1",
-        "contentHash": "WTcjhN/4l6C802QCBHctCZJZAGrVlI5TzVccS+P7s4axvfi0COjMEqHwhQJ4RdzsmblmemHAq4AQay/kc1e75Q=="
-      },
-      "DSInternals.ManagedEsent.Isam": {
-        "type": "Transitive",
-        "resolved": "2.0.4.1",
-        "contentHash": "ttkkBm6GIEylpxSAepD5u9pR8uP1Kf87Fmr0G4f5pgFW5oXRBGWPr8UCitWkx4hdg6hqTV12+IGOTU0oVSaDRA==",
-        "dependencies": {
-          "DSInternals.ManagedEsent.Interop": "2.0.4.1"
-        }
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -217,35 +238,26 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
-        }
-      },
-      "dsinternals.datastore": {
-        "type": "Project",
-        "dependencies": {
-          "DSInternals.Common": "[5.5.0, )",
-          "DSInternals.ManagedEsent.Interop": "[2.0.4.1, )",
-          "DSInternals.ManagedEsent.Isam": "[2.0.4.1, )"
         }
       },
       "dsinternals.replication": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       },
       "dsinternals.replication.model": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       },
       "dsinternals.sam": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       }
     }

--- a/Src/DSInternals.PowerShell/packages.lock.json
+++ b/Src/DSInternals.PowerShell/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -29,24 +20,37 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
       },
+      "DSInternals.ManagedEsent.Interop": {
+        "type": "Transitive",
+        "resolved": "2.0.4.1",
+        "contentHash": "WTcjhN/4l6C802QCBHctCZJZAGrVlI5TzVccS+P7s4axvfi0COjMEqHwhQJ4RdzsmblmemHAq4AQay/kc1e75Q=="
+      },
+      "DSInternals.ManagedEsent.Isam": {
+        "type": "Transitive",
+        "resolved": "2.0.4.1",
+        "contentHash": "ttkkBm6GIEylpxSAepD5u9pR8uP1Kf87Fmr0G4f5pgFW5oXRBGWPr8UCitWkx4hdg6hqTV12+IGOTU0oVSaDRA==",
+        "dependencies": {
+          "DSInternals.ManagedEsent.Interop": "2.0.4.1"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -55,11 +59,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -102,8 +101,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -132,8 +131,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -160,8 +159,16 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
+        }
+      },
+      "dsinternals.datastore": {
+        "type": "Project",
+        "dependencies": {
+          "DSInternals.Common": "[6.0.0, )",
+          "DSInternals.ManagedEsent.Interop": "[2.0.4.1, )",
+          "DSInternals.ManagedEsent.Isam": "[2.0.4.1, )"
         }
       },
       "dsinternals.replication": {
@@ -206,6 +213,19 @@
         "resolved": "9.0.8",
         "contentHash": "xN2JrOfhcOyswOflVZG27XlFJDPPqU7AQtAAStWcnKoC8W9XCLOLdAYIrrwiZMfeRhavVErI8HkSO/c2TQ+z2g=="
       },
+      "DSInternals.ManagedEsent.Interop": {
+        "type": "Transitive",
+        "resolved": "2.0.4.1",
+        "contentHash": "WTcjhN/4l6C802QCBHctCZJZAGrVlI5TzVccS+P7s4axvfi0COjMEqHwhQJ4RdzsmblmemHAq4AQay/kc1e75Q=="
+      },
+      "DSInternals.ManagedEsent.Isam": {
+        "type": "Transitive",
+        "resolved": "2.0.4.1",
+        "contentHash": "ttkkBm6GIEylpxSAepD5u9pR8uP1Kf87Fmr0G4f5pgFW5oXRBGWPr8UCitWkx4hdg6hqTV12+IGOTU0oVSaDRA==",
+        "dependencies": {
+          "DSInternals.ManagedEsent.Interop": "2.0.4.1"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -240,6 +260,14 @@
         "dependencies": {
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
+        }
+      },
+      "dsinternals.datastore": {
+        "type": "Project",
+        "dependencies": {
+          "DSInternals.Common": "[6.0.0, )",
+          "DSInternals.ManagedEsent.Interop": "[2.0.4.1, )",
+          "DSInternals.ManagedEsent.Isam": "[2.0.4.1, )"
         }
       },
       "dsinternals.replication": {

--- a/Src/DSInternals.Replication.Model.Test/packages.lock.json
+++ b/Src/DSInternals.Replication.Model.Test/packages.lock.json
@@ -11,15 +11,6 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -82,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -115,11 +106,6 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -240,8 +226,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -284,8 +270,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -294,15 +280,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -327,7 +313,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },

--- a/Src/DSInternals.Replication.Model.Test/packages.lock.json
+++ b/Src/DSInternals.Replication.Model.Test/packages.lock.json
@@ -11,6 +11,15 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -73,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -106,6 +115,11 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -172,11 +186,6 @@
         "resolved": "3.10.2",
         "contentHash": "WS9GHohjOzf653bqCSxplq3T25LAwFVeVrgLuotTiPDu+bO5bD7RgvXbkLqRqZGE2Qyuk/dbQpqa18PYAMXjMg=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -229,6 +238,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -265,25 +284,25 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "E5M5AE2OUTlCrf4omZvzzziUJO9CofBl+lXHaN5IKePPJvHqYFYYpaDPgCpR4VwaFbEebfnjOxxEBtPtsqAxpQ==",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.11",
-        "contentHash": "xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.1",
+          "System.Text.Encodings.Web": "9.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -304,11 +323,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },
@@ -492,8 +511,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -565,7 +584,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.Replication.Model/packages.lock.json
+++ b/Src/DSInternals.Replication.Model/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -23,8 +14,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -33,11 +24,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -80,8 +66,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -110,8 +96,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -120,15 +106,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -153,7 +139,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }

--- a/Src/DSInternals.Replication.Model/packages.lock.json
+++ b/Src/DSInternals.Replication.Model/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -12,20 +21,28 @@
           "Microsoft.SourceLink.Common": "8.0.0"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -61,6 +78,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -78,8 +105,41 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       },
       "System.ValueTuple": {
         "type": "Transitive",
@@ -89,11 +149,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }
@@ -118,11 +178,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -151,7 +206,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.Replication.Test/packages.lock.json
+++ b/Src/DSInternals.Replication.Test/packages.lock.json
@@ -11,15 +11,6 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -82,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -115,11 +106,6 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -240,8 +226,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -284,8 +270,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -294,15 +280,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -327,7 +313,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },

--- a/Src/DSInternals.Replication.Test/packages.lock.json
+++ b/Src/DSInternals.Replication.Test/packages.lock.json
@@ -11,6 +11,15 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -73,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -106,6 +115,11 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -172,11 +186,6 @@
         "resolved": "3.10.2",
         "contentHash": "WS9GHohjOzf653bqCSxplq3T25LAwFVeVrgLuotTiPDu+bO5bD7RgvXbkLqRqZGE2Qyuk/dbQpqa18PYAMXjMg=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -229,6 +238,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -265,25 +284,25 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "E5M5AE2OUTlCrf4omZvzzziUJO9CofBl+lXHaN5IKePPJvHqYFYYpaDPgCpR4VwaFbEebfnjOxxEBtPtsqAxpQ==",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.11",
-        "contentHash": "xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.1",
+          "System.Text.Encodings.Web": "9.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -304,11 +323,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },

--- a/Src/DSInternals.Replication/packages.lock.json
+++ b/Src/DSInternals.Replication/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -23,8 +14,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -33,11 +24,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -80,8 +66,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -110,8 +96,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -120,15 +106,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -153,8 +139,15 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
+        }
+      },
+      "dsinternals.replication.interop.netframework": {
+        "type": "Project",
+        "dependencies": {
+          "DSInternals.Common": "[1.0.0, )",
+          "DSInternals.Replication.Model": "[1.0.0, )"
         }
       },
       "dsinternals.replication.model": {
@@ -214,6 +207,13 @@
         "dependencies": {
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
+        }
+      },
+      "dsinternals.replication.interop.netcore": {
+        "type": "Project",
+        "dependencies": {
+          "DSInternals.Common": "[6.0.0, )",
+          "DSInternals.Replication.Model": "[6.0.0, )"
         }
       },
       "dsinternals.replication.model": {

--- a/Src/DSInternals.Replication/packages.lock.json
+++ b/Src/DSInternals.Replication/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -12,20 +21,28 @@
           "Microsoft.SourceLink.Common": "8.0.0"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -61,6 +78,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -78,8 +105,41 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       },
       "System.ValueTuple": {
         "type": "Transitive",
@@ -89,25 +149,18 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
-        }
-      },
-      "dsinternals.replication.interop.netframework": {
-        "type": "Project",
-        "dependencies": {
-          "DSInternals.Common": "[1.0.0, )",
-          "DSInternals.Replication.Model": "[1.0.0, )"
         }
       },
       "dsinternals.replication.model": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       }
     },
@@ -131,11 +184,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -164,22 +212,14 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
-        }
-      },
-      "dsinternals.replication.interop.netcore": {
-        "type": "Project",
-        "dependencies": {
-          "DSInternals.Common": "[5.5.0, )",
-          "DSInternals.Replication.Model": "[5.5.0, )"
         }
       },
       "dsinternals.replication.model": {
         "type": "Project",
         "dependencies": {
-          "DSInternals.Common": "[5.5.0, )"
+          "DSInternals.Common": "[6.0.0, )"
         }
       }
     }

--- a/Src/DSInternals.SAM.Test/packages.lock.json
+++ b/Src/DSInternals.SAM.Test/packages.lock.json
@@ -11,15 +11,6 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -82,8 +73,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -115,11 +106,6 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -240,8 +226,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -284,8 +270,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -294,15 +280,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -327,7 +313,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },

--- a/Src/DSInternals.SAM.Test/packages.lock.json
+++ b/Src/DSInternals.SAM.Test/packages.lock.json
@@ -11,6 +11,15 @@
           "Microsoft.CodeCoverage": "17.13.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -73,8 +82,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -106,6 +115,11 @@
           "System.Text.Encodings.Web": "6.0.1",
           "System.Text.Json": "6.0.11"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -172,11 +186,6 @@
         "resolved": "3.10.2",
         "contentHash": "WS9GHohjOzf653bqCSxplq3T25LAwFVeVrgLuotTiPDu+bO5bD7RgvXbkLqRqZGE2Qyuk/dbQpqa18PYAMXjMg=="
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -229,6 +238,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -265,25 +284,25 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "E5M5AE2OUTlCrf4omZvzzziUJO9CofBl+lXHaN5IKePPJvHqYFYYpaDPgCpR4VwaFbEebfnjOxxEBtPtsqAxpQ==",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.11",
-        "contentHash": "xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
           "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.1",
+          "System.Text.Encodings.Web": "9.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -304,11 +323,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       },
@@ -492,8 +511,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -565,7 +584,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }

--- a/Src/DSInternals.SAM/packages.lock.json
+++ b/Src/DSInternals.SAM/packages.lock.json
@@ -2,15 +2,6 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
-      "Microsoft.NETFramework.ReferenceAssemblies": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
-        "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
-        }
-      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -34,8 +25,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "resolved": "9.0.8",
+        "contentHash": "mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -44,11 +35,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
-      },
-      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
-        "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -109,8 +95,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "resolved": "9.0.8",
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -139,8 +125,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "resolved": "9.0.8",
+        "contentHash": "W+LotQsM4wBJ4PG7uRkyul4wqL4Fz7R4ty6uXrCNZUhbaHYANgrPaYR2ZpMVpdCjQEJ17Jr1NMN8hv4SHaHY4A==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
@@ -149,15 +135,15 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "resolved": "9.0.8",
+        "contentHash": "mIQir9jBqk0V7X0Nw5hzPJZC8DuGdf+2DS3jAVsr6rq5+/VyH5rza0XGcONJUWBrZ+G6BCwNyjWYd9lncBu48A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.0",
+          "System.IO.Pipelines": "9.0.8",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
+          "System.Text.Encodings.Web": "9.0.8",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         }
@@ -182,7 +168,7 @@
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
-          "System.Text.Json": "[9.0.0, )",
+          "System.Text.Json": "[9.0.8, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }

--- a/Src/DSInternals.SAM/packages.lock.json
+++ b/Src/DSInternals.SAM/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -23,10 +32,23 @@
           "Microsoft.Windows.WDK.Win32Metadata": "0.12.8-experimental"
         }
       },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -50,11 +72,6 @@
         "dependencies": {
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview"
         }
-      },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "PeterO.Cbor": {
         "type": "Transitive",
@@ -90,6 +107,16 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -107,8 +134,41 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.3",
-        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.0",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
       },
       "System.ValueTuple": {
         "type": "Transitive",
@@ -118,11 +178,11 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.Buffers": "[4.5.1, )",
           "System.Formats.Asn1": "[9.0.8, )",
           "System.Memory": "[4.5.5, )",
+          "System.Text.Json": "[9.0.0, )",
           "System.ValueTuple": "[4.6.1, )"
         }
       }
@@ -177,11 +237,6 @@
           "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview"
         }
       },
-      "Newtonsoft.Json": {
-        "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
       "PeterO.Cbor": {
         "type": "Transitive",
         "resolved": "4.5.5",
@@ -209,7 +264,6 @@
       "dsinternals.common": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.3, )",
           "PeterO.Cbor": "[4.5.5, )",
           "System.DirectoryServices": "[9.0.8, )"
         }


### PR DESCRIPTION
**What changed**

Introduced `DsiJson` helper with one place for serializer config: case-insensitive props, comments + trailing commas allowed, `IncludeFields` (for LAPS), `JsonStringEnumConverter`, and a fallback that normalizes single-quoted JSON.

- Replaced all `JsonConvert` calls with `JsonSerializer` and routed model parsing/serialization through `DsiJson`.
- Added/updated `System.Text.Json` attributes on models (`[JsonPropertyName]`, `[JsonInclude]` for private setters) so deserialization matches previous behavior.
- LAPS parsing handles binary JSON (UTF-8/UTF-16) and trims terminators/BOM centrally.
- Multi-target: net48;net8.0-windows. `System.Text.Json` package is only referenced for net48 (PS 5.1). net8.0-windows uses the in-box framework copy (PS 7).
- Added `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` as I use it in my modules/binaries but not sure if you believe it's not needed.
- Tests updated/added for single-quoted input, comments, trailing commas, and round-trips. Where comparisons were stringy (e.g., + vs \u002B), assertions were made semantic.

**Compatibility notes**
- Public API surface unchanged.
- JSON shape unchanged; output escaping may differ (+ vs \u002B) but values are identical.
- No changes to `System.DirectoryServices` or RSA code paths.

**Status**
All JSON-related tests pass. Some tests fail, but I confirmed with the master before changes and it fails as well for me. 

<img width="1148" height="505" alt="image" src="https://github.com/user-attachments/assets/77429f43-b87f-43d4-ab78-babc2ad033c8" />
