### PR TITLE
Resolved #136: Propagate RPC session key changes mid-replication

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 - WKS resource records now emit lowercase `tcp`/`udp` and translate port numbers to IANA service names (e.g. `25` → `smtp`) using the system `services` file, with a fallback to the numeric port.
+- Fixed intermittent `CRC check failed.` errors during replication caused by the RPC session key being renegotiated mid-replication. `DrsConnection` now raises a `SessionKeyChanged` event and the secret decryptor follows the current key while retaining previously seen keys, so accounts encrypted under either key still decrypt ([#136](https://github.com/MichaelGrafnetter/DSInternals/issues/136)).
 
 ## [6.5] - 2026-05-16
 

--- a/Src/DSInternals.Replication.Interop/DrsConnection.cpp
+++ b/Src/DSInternals.Replication.Interop/DrsConnection.cpp
@@ -26,7 +26,7 @@ namespace DSInternals::Replication::Interop
         this->_serverReplEpoch = DrsConnection::DefaultReplEpoch;
         this->_schema = schema;
 
-        // Register the RetrieveSessionKey as RCP security callback. Mind the delegate lifecycle.
+        // Register the RetrieveSessionKey as RPC security callback. Mind the delegate lifecycle.
         this->_securityCallback = gcnew SecurityCallback(this, &DrsConnection::RetrieveSessionKey);
         RPC_STATUS status = RpcBindingSetOption(rpcHandle.ToPointer(), RPC_C_OPT_SECURITY_CALLBACK, (ULONG_PTR)Marshal::GetFunctionPointerForDelegate(this->_securityCallback).ToPointer());
 
@@ -809,14 +809,41 @@ namespace DSInternals::Replication::Interop
         // Extract the actual key if the authentication schema uses one
         if (secStatus == SEC_E_OK && nativeKey.SessionKey != nullptr)
         {
-            array<byte>^ managedKey = gcnew array<byte>(nativeKey.SessionKeyLength);
-            // Pin it so the GC does not touch it
-            pin_ptr<byte> pinnedManagedKey = &managedKey[0];
-            // Copy data from native to managed memory
-            memcpy(pinnedManagedKey, nativeKey.SessionKey, nativeKey.SessionKeyLength);
+            // The security callback fires on every RPC. Avoid allocating a managed buffer when the
+            // key is unchanged by pinning the current _sessionKey and memcmp'ing against the
+            // native buffer directly.
+            array<byte>^ existingKey = this->_sessionKey;
+            bool keyChanged = existingKey == nullptr || existingKey->Length != (int)nativeKey.SessionKeyLength;
+
+            if (!keyChanged)
+            {
+                pin_ptr<byte> pinnedExistingKey = &existingKey[0];
+                keyChanged = memcmp(pinnedExistingKey, nativeKey.SessionKey, nativeKey.SessionKeyLength) != 0;
+            }
+
+            if (keyChanged)
+            {
+                // Allocate a fresh managed buffer for the new key. We never overwrite an existing
+                // buffer in place: subscribers (e.g. the secret decryptor's fallback history) keep
+                // references to previous keys and must observe stable bytes.
+                array<byte>^ newKey = gcnew array<byte>(nativeKey.SessionKeyLength);
+                pin_ptr<byte> pinnedNewKey = &newKey[0];
+                memcpy(pinnedNewKey, nativeKey.SessionKey, nativeKey.SessionKeyLength);
+                this->_sessionKey = newKey;
+
+                // Notify subscribers (e.g. the secret decryptor) about the new key. A handler
+                // exception must never escape into the native RPC runtime across this callback.
+                try
+                {
+                    SessionKeyChanged(this, gcnew SessionKeyChangedEventArgs(newKey));
+                }
+                catch (Exception^)
+                {
+                }
+            }
+
             // Do not forget to free the unmanaged memory
             secStatus = FreeContextBuffer(nativeKey.SessionKey);
-            this->_sessionKey = managedKey;
         }
     }
 

--- a/Src/DSInternals.Replication.Interop/DrsConnection.h
+++ b/Src/DSInternals.Replication.Interop/DrsConnection.h
@@ -46,6 +46,8 @@ namespace DSInternals::Replication::Interop
         {
             cli::array<byte>^ get();
         }
+        // Raised whenever the RPC layer negotiates a new session key mid-connection.
+        event EventHandler<SessionKeyChangedEventArgs^>^ SessionKeyChanged;
         property Guid ServerSiteGuid
         {
             Guid get();

--- a/Src/DSInternals.Replication.Model/SessionKeyChangedEventArgs.cs
+++ b/Src/DSInternals.Replication.Model/SessionKeyChangedEventArgs.cs
@@ -1,0 +1,21 @@
+namespace DSInternals.Replication.Model;
+
+/// <summary>
+/// Provides data for the event raised when the RPC session key is renegotiated.
+/// </summary>
+public class SessionKeyChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the newly negotiated session key.
+    /// </summary>
+    public byte[] SessionKey { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionKeyChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="sessionKey">The newly negotiated session key.</param>
+    public SessionKeyChangedEventArgs(byte[] sessionKey)
+    {
+        this.SessionKey = sessionKey;
+    }
+}

--- a/Src/DSInternals.Replication.Test/ReplicationSecretDecryptorTester.cs
+++ b/Src/DSInternals.Replication.Test/ReplicationSecretDecryptorTester.cs
@@ -75,6 +75,50 @@ public class ReplicationSecretDecryptorTester
 
 
     [TestMethod]
+    public void PasswordEncryptionKey_SessionKeyChange_UsesLatestKey()
+    {
+        // The session key was renegotiated after the decryptor was created, so the current key
+        // (passed via ChangeSessionKey) is the one that must be used.
+        byte[] staleKey = "00000000000000000000000000000000".HexToBinary();
+        byte[] currentKey = "b0133bfc9ce59c805dd15d5872e247c5".HexToBinary();
+        var pek = new ReplicationSecretDecryptor(staleKey);
+        pek.ChangeSessionKey(currentKey);
+
+        byte[] blob = "e650e0179becf540e1e6dbe37deb38b379618228d74d9ff7e08a588c2a6fbd511ad78f61".HexToBinary();
+        string result = pek.DecryptHash(blob, 500).ToHex(true);
+        Assert.AreEqual("92937945B518814341DE3F726500D4FF", result);
+    }
+
+    [TestMethod]
+    public void PasswordEncryptionKey_SessionKeyChange_FallsBackToPreviousKey()
+    {
+        // Simulates GuyTe's "mid-page" case: the key changed, but this particular secret was
+        // encrypted under the previous key. The latest key fails the CRC check, so the decryptor
+        // must fall back to the retained previous key.
+        byte[] previousKey = "b0133bfc9ce59c805dd15d5872e247c5".HexToBinary();
+        byte[] currentKey = "00000000000000000000000000000000".HexToBinary();
+        var pek = new ReplicationSecretDecryptor(previousKey);
+        pek.ChangeSessionKey(currentKey);
+
+        byte[] blob = "e650e0179becf540e1e6dbe37deb38b379618228d74d9ff7e08a588c2a6fbd511ad78f61".HexToBinary();
+        string result = pek.DecryptHash(blob, 500).ToHex(true);
+        Assert.AreEqual("92937945B518814341DE3F726500D4FF", result);
+    }
+
+    [TestMethod]
+    public void PasswordEncryptionKey_SessionKeyChange_NoMatchingKeyThrows()
+    {
+        // None of the known keys can decrypt the blob, so the CRC check must fail for all of them.
+        byte[] wrongKey1 = "00000000000000000000000000000000".HexToBinary();
+        byte[] wrongKey2 = "11111111111111111111111111111111".HexToBinary();
+        var pek = new ReplicationSecretDecryptor(wrongKey1);
+        pek.ChangeSessionKey(wrongKey2);
+
+        byte[] blob = "e650e0179becf540e1e6dbe37deb38b379618228d74d9ff7e08a588c2a6fbd511ad78f61".HexToBinary();
+        Assert.ThrowsExactly<FormatException>(() => pek.DecryptHash(blob, 500));
+    }
+
+    [TestMethod]
     public void PasswordEncryptionKey_NullInput()
     {
         throw new AssertInconclusiveException();

--- a/Src/DSInternals.Replication/DirectoryReplicationClient.cs
+++ b/Src/DSInternals.Replication/DirectoryReplicationClient.cs
@@ -58,6 +58,7 @@ public class DirectoryReplicationClient : IDisposable, IKdsRootKeyResolver
     private readonly Lazy<(string DomainNamingContext, string NetBIOSDomainName)> _domainInfo;
     private readonly Lazy<string[]> _namingContexts;
     private readonly Lazy<DirectorySecretDecryptor> _secretDecryptor;
+    private EventHandler<SessionKeyChangedEventArgs> _sessionKeyChangedHandler;
 
     /// <summary>
     /// The domain naming context of the connected server.
@@ -121,7 +122,17 @@ public class DirectoryReplicationClient : IDisposable, IKdsRootKeyResolver
         // Lazily fetch domain info, naming contexts, and the secret decryptor on first access.
         this._domainInfo = new Lazy<(string, string)>(this.LoadDomainInfo);
         this._namingContexts = new Lazy<string[]>(() => this._drsConnection.ListNamingContexts());
-        this._secretDecryptor = new Lazy<DirectorySecretDecryptor>(() => new ReplicationSecretDecryptor(this._drsConnection.SessionKey));
+        this._secretDecryptor = new Lazy<DirectorySecretDecryptor>(() =>
+        {
+            var decryptor = new ReplicationSecretDecryptor(this._drsConnection.SessionKey);
+
+            // The RPC session key can be renegotiated mid-replication. Forward those changes to the
+            // decryptor so it always tries the current key (while retaining the previous ones).
+            this._sessionKeyChangedHandler = (sender, e) => decryptor.ChangeSessionKey(e.SessionKey);
+            this._drsConnection.SessionKeyChanged += this._sessionKeyChangedHandler;
+
+            return decryptor;
+        });
     }
 
     /// <summary>
@@ -512,6 +523,12 @@ public class DirectoryReplicationClient : IDisposable, IKdsRootKeyResolver
 
         if (this._drsConnection != null)
         {
+            if (this._sessionKeyChangedHandler != null)
+            {
+                this._drsConnection.SessionKeyChanged -= this._sessionKeyChangedHandler;
+                this._sessionKeyChangedHandler = null;
+            }
+
             this._drsConnection.Dispose();
             this._drsConnection = null;
         }

--- a/Src/DSInternals.Replication/ReplicationSecretDecryptor.cs
+++ b/Src/DSInternals.Replication/ReplicationSecretDecryptor.cs
@@ -19,14 +19,19 @@ public class ReplicationSecretDecryptor : DirectorySecretDecryptor
     private const int EncryptedBlobMinSize = SaltSize + 1;
 
     /// <summary>
-    /// Decryption key.
+    /// Decryption keys, ordered most-recently-negotiated first.
     /// </summary>
-    private byte[] key;
+    /// <remarks>
+    /// The RPC session key can be renegotiated mid-replication, so secrets within a single
+    /// replication stream may be encrypted under different keys. We therefore keep every key we
+    /// have seen and try them newest-first when decrypting.
+    /// </remarks>
+    private readonly List<byte[]> sessionKeys;
 
     /// <summary>
-    /// Gets the current decryption key.
+    /// Gets the most recently negotiated decryption key.
     /// </summary>
-    public override byte[] CurrentKey => this.key;
+    public override byte[] CurrentKey => this.sessionKeys[0];
 
     /// <summary>
     /// Gets the encryption algorithm used to protect the secrets.
@@ -36,13 +41,30 @@ public class ReplicationSecretDecryptor : DirectorySecretDecryptor
     /// <summary>
     /// Initializes a new instance of the <see cref="ReplicationSecretDecryptor"/> class.
     /// </summary>
-    /// <param name="key">The decryption key.</param>
-    public ReplicationSecretDecryptor(byte[] key)
+    /// <param name="initialSessionKey">The session key in effect when the decryptor is created.</param>
+    public ReplicationSecretDecryptor(byte[] initialSessionKey)
     {
-        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(initialSessionKey);
         // Session key size: NTLM - 16B, Kerberos - 32B
-        Validator.AssertMinLength(key, KeySize);
-        this.key = key;
+        Validator.AssertMinLength(initialSessionKey, KeySize);
+        this.sessionKeys = new List<byte[]>() { initialSessionKey };
+    }
+
+    /// <summary>
+    /// Registers a newly negotiated session key as the preferred decryption key.
+    /// </summary>
+    /// <param name="newKey">The new session key.</param>
+    /// <remarks>
+    /// Previously seen keys are retained so that secrets encrypted before the renegotiation can
+    /// still be decrypted. This method does not throw, as it is invoked from an event raised inside
+    /// the native RPC security callback.
+    /// </remarks>
+    public void ChangeSessionKey(byte[] newKey)
+    {
+        if (newKey != null)
+        {
+            this.sessionKeys.Insert(0, newKey);
+        }
     }
 
     /// <summary>
@@ -59,16 +81,23 @@ public class ReplicationSecretDecryptor : DirectorySecretDecryptor
         byte[] salt = blob.Cut(SaltOffset, SaltSize);
         byte[] encryptedSecret = blob.Cut(SaltOffset + SaltSize);
 
-        // Perform decryption
-        byte[] decryptedBlob = DecryptUsingRC4(encryptedSecret, salt, this.CurrentKey);
+        // The session key may have been renegotiated mid-replication, so try the keys we have seen
+        // newest-first and accept the first one that yields a valid CRC.
+        foreach (byte[] sessionKey in this.sessionKeys)
+        {
+            byte[] decryptedBlob = DecryptUsingRC4(encryptedSecret, salt, sessionKey);
 
-        // The blob is prepended with CRC
-        byte[] decryptedSecret;
-        uint expectedCrc = BitConverter.ToUInt32(decryptedBlob, 0);
-        decryptedSecret = decryptedBlob.Cut(sizeof(uint));
-        Validator.AssertCrcMatches(decryptedSecret, expectedCrc);
+            // The blob is prepended with CRC
+            uint expectedCrc = BitConverter.ToUInt32(decryptedBlob, 0);
+            byte[] decryptedSecret = decryptedBlob.Cut(sizeof(uint));
+            if (Crc32.Calculate(decryptedSecret) == expectedCrc)
+            {
+                return decryptedSecret;
+            }
+        }
 
-        return decryptedSecret;
+        // None of the known session keys produced a valid CRC.
+        throw new FormatException("Secret decryption failed: CRC check did not match for any known session key.");
     }
 
     /// <summary>

--- a/Src/DSInternals.Replication/packages.lock.json
+++ b/Src/DSInternals.Replication/packages.lock.json
@@ -252,7 +252,7 @@
           "System.Formats.Cbor": "[9.0.9, )"
         }
       },
-      "dsinternals.replication.interop.netcore": {
+      "DSInternals.Replication.Interop": {
         "type": "Project",
         "dependencies": {
           "DSInternals.Common": "[6.5.0, )",


### PR DESCRIPTION
Fixes #136.

## Why

`Get-ADReplAccount` (and other replication consumers) intermittently failed with `CRC check failed.` when a random handful of accounts decrypted to garbage. A subsequent pass typically broke on a *different* set of accounts. As @GuyTe diagnosed in the issue thread, the RPC session key is renegotiated mid-replication (Kerberos ticket renewal). The C++/CLI security callback `DrsConnection::RetrieveSessionKey` already updated `_sessionKey`, but `ReplicationSecretDecryptor` had snapshotted the key at construction and kept using the stale one — so every secret encrypted after a rollover failed CRC. @GuyTe also noted a harder edge case: a single page whose objects are split across **two** keys ("mid-page mix"). This PR covers both.

## What

Event-driven push from the connection to the decryptor, with full key-history retention:

- **New `SessionKeyChangedEventArgs`** in `DSInternals.Replication.Model`, carrying the new `byte[] SessionKey`.
- **`DrsConnection`** gains a `SessionKeyChanged` event. `RetrieveSessionKey` now compares the freshly negotiated key against the previous one *without* a managed allocation — it pins `_sessionKey` and `memcmp`s against the native buffer. On an actual change it allocates a fresh `byte[]`, copies the bytes in, replaces `_sessionKey`, and raises the event (existing buffers are never mutated in place, so subscriber references stay stable). The event raise is wrapped in `try/catch (Exception^)` so a handler exception can never escape into the native RPC runtime.
- **`ReplicationSecretDecryptor`** now keeps every session key it has been given in a `List<byte[]>` (most recent first). `DecryptSecret` tries the keys newest-first and returns the first whose CRC validates; only if all of them fail does it throw. The constructor parameter is renamed to `initialSessionKey`, and a new `ChangeSessionKey(byte[])` method inserts a new key at the front. On total failure it throws `FormatException("Secret decryption failed: CRC check did not match for any known session key.")` — the old `CRC check failed.` message was too thin to debug against.
- **`DirectoryReplicationClient`** subscribes the decryptor's `ChangeSessionKey` to the connection's event inside the `Lazy<DirectorySecretDecryptor>` factory, storing the handler in a field, and detaches it with `-=` in `Dispose` before releasing the connection.

The decryptor stores the byte arrays it receives by reference — safe because `DrsConnection` always allocates a fresh buffer on a real change and never mutates a buffer it has already handed out.

## Why this resolves both the original report and GuyTe's mid-page case

The replication iterator is pull-based: page *N*'s RPC completes (updating the session key and raising the event before any of its objects are decrypted), then page *N*'s objects are pulled and decrypted, then page *N+1* is fetched. So the *current* key is always correct for between-page changes. For the mid-page case, when the in-page change is observed by the callback, the older key is still in the decryptor's history list — so a secret encrypted under the older key falls through to the previous entry and decrypts cleanly.

## Test plan

- [x] Full `DSInternals.slnx` build (x64 Debug) — succeeded, including both C++/CLI Interop flavors (NetCore + NetFramework).
- [x] `DSInternals.Replication.Test` — **7 passed**, 1 skipped (pre-existing `PasswordEncryptionKey_NullInput` placeholder), 0 failed. Three new tests cover the multi-key behavior using the existing NT-hash vector:
  - `PasswordEncryptionKey_SessionKeyChange_UsesLatestKey` — seed wrong key, `ChangeSessionKey(correctKey)`, decrypt → expected hash.
  - `PasswordEncryptionKey_SessionKeyChange_FallsBackToPreviousKey` — seed correctKey, `ChangeSessionKey(wrongKey)` (mid-page simulation), decrypt → falls back to the older key.
  - `PasswordEncryptionKey_SessionKeyChange_NoMatchingKeyThrows` — only wrong keys present → throws `FormatException`.
- [ ] **Manual lab verification (cannot run here, requires a DC):** @GuyTe's repro — `Get-ADReplAccount -All` until done and save the cookie, perform a mass password reset on many accounts, replicate again with the saved cookie. Before this PR throws `CRC check failed.` for a random subset; after this PR all accounts decrypt.

## Public API

Additive only:
- New `SessionKeyChangedEventArgs` type.
- New `DrsConnection.SessionKeyChanged` event.
- New `ReplicationSecretDecryptor.ChangeSessionKey(byte[])` method; constructor parameter renamed `key` → `initialSessionKey` (positional callers unaffected).

The singular `DrsConnection.SessionKey` property is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)