### PR TITLE
Resolved #220: Default SupportsKerberosAESEncryption to true when attribute is unset

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - WKS resource records now emit lowercase `tcp`/`udp` and translate port numbers to IANA service names (e.g. `25` → `smtp`) using the system `services` file, with a fallback to the numeric port.
 - Fixed intermittent `CRC check failed.` errors during replication caused by the RPC session key being renegotiated mid-replication. `DrsConnection` now raises a `SessionKeyChanged` event and the secret decryptor follows the current key while retaining previously seen keys, so accounts encrypted under either key still decrypt ([#136](https://github.com/MichaelGrafnetter/DSInternals/issues/136)).
+- Resolved [#220](https://github.com/MichaelGrafnetter/DSInternals/issues/220): `DSAccount.SupportsKerberosAESEncryption` now returns `true` when the `msDS-SupportedEncryptionTypes` attribute is unset, matching the behaviour of modern DCs that honour `DefaultDomainSupportedEncTypes`. This removes false-positive Kerberoastable findings from [Test-PasswordQuality](PowerShell/Test-PasswordQuality.md#test-passwordquality) for accounts that have never had the attribute explicitly configured.
 
 ## [6.5] - 2026-05-16
 

--- a/Src/DSInternals.Common/Data/Principals/DSAccount.cs
+++ b/Src/DSInternals.Common/Data/Principals/DSAccount.cs
@@ -167,7 +167,11 @@ public class DSAccount
         {
             if (!this.SupportedEncryptionTypes.HasValue)
             {
-                return false;
+                // An unset msDS-SupportedEncryptionTypes attribute means the account
+                // inherits the domain default. Since KB5021131, DCs honour the
+                // DefaultDomainSupportedEncTypes setting, which includes AES on all
+                // currently supported Windows Server versions.
+                return true;
             }
 
             return this.SupportedEncryptionTypes.Value.HasFlag(Data.SupportedEncryptionTypes.AES128_CTS_HMAC_SHA1_96) ||


### PR DESCRIPTION
## Summary

- `DSAccount.SupportsKerberosAESEncryption` now returns `true` when `msDS-SupportedEncryptionTypes` is unset, instead of `false`.
- Removes false-positive Kerberoastable findings from `Test-PasswordQuality` for accounts that have never had the attribute explicitly configured.
- Adds a `Resolved #220` entry under the `Unreleased` → `Fixed` section of the changelog.

## Why

Reported in [#220](https://github.com/MichaelGrafnetter/DSInternals/issues/220) by @HoffmannTom. An empty `msDS-SupportedEncryptionTypes` attribute means the account inherits the domain default; on post-KB5021131 DCs that default is `DefaultDomainSupportedEncTypes`, which includes AES on all currently supported Windows Server versions. The previous `return false` therefore flagged accounts as Kerberoastable purely because the attribute had never been touched.

The inverse risk (an admin who explicitly disabled AES but did *not* set the attribute) is implausible — disabling AES requires deliberately setting a value.

The alternative of returning a nullable `bool?` and softening the warning message was considered but rejected: it would be a binary-breaking API change for Framework consumers and would require splitting `PasswordQualityTestResult.Kerberoastable`. Not worth it for an `Unreleased` quick win.

## Test plan

- [x] `dotnet build DSInternals.DotNetSdk.slnf -c Debug` — clean, 0 errors
- [x] `dotnet test --solution DSInternals.DotNetSdk.slnf` — **1050 passed**, 60 skipped (pre-existing), 0 failed
- [ ] Manual smoke check against an ntds.dit: confirm the `Kerberoastable` count drops by the number of SPN-bearing accounts with unset `msDS-SupportedEncryptionTypes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)